### PR TITLE
Depend on our tap of libght

### DIFF
--- a/Formula/pointcloud.rb
+++ b/Formula/pointcloud.rb
@@ -14,7 +14,7 @@ class Pointcloud < Formula
 
   depends_on "cmake" => :build
   depends_on :postgresql
-  depends_on "libght"
+  depends_on "osgeo/osgeo4mac/libght"
   depends_on "cunit" if build.with? "tests"
 
   def install


### PR DESCRIPTION
Without specifying the tap path, `brew install osgeo/osgeo4mac/pointcloud` fails on my system with:

```
Error: No available formula for libght (dependency of pointcloud)
```

We need to specify the full path to the formula for the install to succeed.
