### PR TITLE
orfeo-42: fixed download url

### DIFF
--- a/Formula/orfeo-42.rb
+++ b/Formula/orfeo-42.rb
@@ -1,6 +1,6 @@
 class Orfeo42 < Formula
   homepage "http://www.orfeo-toolbox.org/otb/"
-  url "https://downloads.sourceforge.net/project/orfeo-toolbox/OTB-4.2.1.tgz"
+  url "http://downloads.sourceforge.net/project/orfeo-toolbox/OTB/OTB-4.2.1/OTB-4.2.1.tgz"
   sha1 "c4f1299a2828a6f6acb81c1e022c706b7b7f10ea"
 
   bottle do


### PR DESCRIPTION
I changed the URL, but the installation still fails. ::

    ...
    -- Check size of __int64
    -- Check size of __int64 - failed
    -- Check size of long int
    -- Check size of long int - done
    -- Check size of short int
    -- Check size of short int - done
    CMake Error at /usr/local/Cellar/cmake/3.1.2/share/cmake/Modules/CMakeExportBuildSettings.cmake:17 (message):
      The functionality of this module has been dropped as of CMake 2.8.  It was
      deemed harmful (confusing users by changing their compiler).  Please remove
      calls to the CMAKE_EXPORT_BUILD_SETTINGS macro and stop including this
      module.  If this project generates any files for use by external projects,
      remove any use of the CMakeImportBuildSettings module from them.
    Call Stack (most recent call first):
      CMakeLists.txt:362 (include)


    -- Configuring incomplete, errors occurred!
    See also "/tmp/orfeo-42-iKXb85/OTB-4.2.1/build/CMakeFiles/CMakeOutput.log".
    See also "/tmp/orfeo-42-iKXb85/OTB-4.2.1/build/CMakeFiles/CMakeError.log"

    ... 

This occured after invoking ::

    brew install -v https://raw.githubusercontent.com/quiqua/homebrew-osgeo4mac/orfeo-42/Formula/orfeo-42.rb

I am running::

    brew --config
    HOMEBREW_VERSION: 0.9.5
    ORIGIN: https://github.com/Homebrew/homebrew
    HEAD: c3c6a3b92855c3917e554c16da0cb672363cf02e
    Last commit: 5 hours ago
    HOMEBREW_PREFIX: /usr/local
    HOMEBREW_CELLAR: /usr/local/Cellar
    CPU: quad-core 64-bit haswell
    OS X: 10.10.2-x86_64
    Xcode: 6.1.1
    CLT: N/A
    Clang: 6.0 build 600
    X11: 2.7.7 => /opt/X11
    System Ruby: 2.0.0-p481
    Perl: /usr/bin/perl
    Python: /usr/local/bin/python => /usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/bin/python2.7
    Ruby: /usr/bin/ruby
    Java: 1.8.0_20

with cmake 3.1.2

Let me know, where I should continue to make the PR fully working.