### PR TITLE
qgis_28 formula point to the 2.8 release branch

### DIFF
--- a/Formula/qgis-28.rb
+++ b/Formula/qgis-28.rb
@@ -25,7 +25,7 @@ class Qgis28 < Formula
     brewed_python?
   end
 
-  head "https://github.com/qgis/QGIS.git", :branch => "master"
+  head "https://github.com/qgis/QGIS.git", :branch => "release-2_8"
 
   option "enable-isolation", "Isolate .app's environment to HOMEBREW_PREFIX, to coexist with other QGIS installs"
   option "with-debug", "Enable debug build, which outputs info to system.log or console"


### PR DESCRIPTION
Change the QGIS version downloaded with the --head option to be the 2.8 branch, rather than the master branch (which isn't 2.8).