### PR TITLE
README: update main Homebrew documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ removed from this tap.
 
 Docs
 ----
-`brew help`, `man brew`, or the Homebrew [wiki][].
+`brew help`, `man brew`, or the Homebrew [documentation][].
 
 [homebrew]:http://brew.sh
 [taps]:https://github.com/Homebrew/homebrew-versions
-[wiki]:https://github.com/Homebrew/homebrew/wiki
+[documentation]:https://github.com/Homebrew/brew/tree/master/docs#readme


### PR DESCRIPTION
The "wiki" link in the README is pointing at the old legacy Homebrew repo. It's deprecated, and there's no wiki there. This PR points users to the current Homebrew documentation instead. (Doco is maintained inside the Homebrew repo now; there's no wiki.)