### PR TITLE
[WIP] Mongo support for gdal, help or review appreciated

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -29,7 +29,6 @@ class Gdal2 < Formula
   option "with-libkml", "Build with Google's libkml driver (requires libkml --HEAD or >= 1.3)"
   option "without-python", "Build without python2 support"
   option "with-swig-java", "Build the swig java bindings"
-  option "with-mongocxx", "Add MongoDB support through the C++ driver"
 
   deprecated_option "enable-opencl" => "with-opencl"
   deprecated_option "enable-armadillo" => "with-armadillo"
@@ -51,6 +50,7 @@ class Gdal2 < Formula
 
   depends_on "postgresql" => :optional
   depends_on "mysql" => :optional
+  depends_on "libmongoclient-legacy" => :optional
 
   depends_on "homebrew/science/armadillo" if build.with? "armadillo"
 
@@ -203,7 +203,11 @@ class Gdal2 < Formula
     # Database support.
     args << (build.with?("postgresql") ? "--with-pg=#{HOMEBREW_PREFIX}/bin/pg_config" : "--without-pg")
     args << (build.with?("mysql") ? "--with-mysql=#{HOMEBREW_PREFIX}/bin/mysql_config" : "--without-mysql")
-    args << (build.with?("mongocxx") ? "--with-mongocxx=/usr/local/opt/mongo-client-install/" : "--without-mongocxx")
+
+    if build.with? "libmongoclient-legacy"
+      args << "--with-mongocxx=#{HOMEBREW_PREFIX}"
+      args << "--with-boost-lib-path=#{HOMEBREW_PREFIX}"
+    end
 
     if build.with? "mdb"
       args << "--with-java=yes"

--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -29,6 +29,7 @@ class Gdal2 < Formula
   option "with-libkml", "Build with Google's libkml driver (requires libkml --HEAD or >= 1.3)"
   option "without-python", "Build without python2 support"
   option "with-swig-java", "Build the swig java bindings"
+  option "with-mongocxx", "Add MongoDB support through the C++ driver"
 
   deprecated_option "enable-opencl" => "with-opencl"
   deprecated_option "enable-armadillo" => "with-armadillo"
@@ -202,6 +203,7 @@ class Gdal2 < Formula
     # Database support.
     args << (build.with?("postgresql") ? "--with-pg=#{HOMEBREW_PREFIX}/bin/pg_config" : "--without-pg")
     args << (build.with?("mysql") ? "--with-mysql=#{HOMEBREW_PREFIX}/bin/mysql_config" : "--without-mysql")
+    args << (build.with?("mongocxx") ? "--with-mongocxx=/usr/local/opt/mongo-client-install/" : "--without-mongocxx")
 
     if build.with? "mdb"
       args << "--with-java=yes"


### PR DESCRIPTION
The MongoDB support is almost working, but I seem to face a general Homebrew problem with libboost. **Any help** from a more experienced brewer is very welcome :-)

In theory, the simple `with-mongocxx` command should be enough, but libboost is not found properly. Therefore it is required to specify `--with-boost-lib-path`.

Trying the install straight forward will end with the following `ld: library not found for lboost_thread`

Installing boost will create `/usr/local/lib/libboost_thread-mt.*` files. I've tried to symlink these by hand with `ln -s /usr/local/lib/libboost_thread-mt.dylib /usr/local/lib/libboost_thread.dylib`, which makes the compilation successfull.

Unfortunately then I end up with the following:

`/usr/local/opt/gdal2/bin/ogr2ogr --version`
```dyld: Symbol not found: __ZN5boost16re_detail_10610013get_mem_blockEv
  Referenced from: /usr/local/opt/libmongoclient-legacy/lib/libmongoclient.dylib
  Expected in: /usr/local/opt/boost/lib/libboost_regex-mt.dylib
 in /usr/local/opt/libmongoclient-legacy/lib/libmongoclient.dylib```

Input highly appreciated