### PR TITLE
Add qt5-webkit-5.8.0_1.el_capitan.bottle

### DIFF
--- a/Formula/qt5-webkit.rb
+++ b/Formula/qt5-webkit.rb
@@ -20,6 +20,11 @@ class Qt5Webkit < Formula
     sha256 "a1831140aa624f9b7ef418f6507c43b2c074b87e5456f0fc18ce99d3ebc7e054" => :sierra
   end
 
+  bottle do
+    root_url "https://github.com/OSGeo/homebrew-osgeo4mac/releases/download/qt5-webkit-5.8.0_1"
+    sha256 "afb17b4532b3fa1885739ae9f57f2783546f39600330c76a90d20fdbf24a80aa" => :el_capitan
+  end
+
   keg_only "Qt5 is keg-only"
 
   depends_on NoQt5WebKitAlreadyRequirement


### PR DESCRIPTION
The bottle was uploaded to the [release section of homebrew-osgeo4mac](https://github.com/OSGeo/homebrew-osgeo4mac/releases). If you prefer to put it somewhere else, just drop it there and delete the release again. On the other hand, I think this could potentially be a good place to use as repository. We can also upload directly from the ci builds (see [qgep example](https://github.com/QGEP/datamodel/blob/master/scripts/release_db_template.py#L18-L40).