### PR TITLE
gdal2: drop podofo when using --with-complete and use poppler instead

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -77,7 +77,6 @@ class Gdal2 < Formula
     # Other libraries
     depends_on "xz" # get liblzma compression algorithm library from XZutils
     depends_on "poppler"
-    depends_on "podofo"
     depends_on "json-c"
   end
 
@@ -147,7 +146,7 @@ class Gdal2 < Formula
       epsilon
       webp
       openjpeg
-      podofo
+      poppler
     ]
     if build.with? "complete"
       supported_backends.delete "liblzma"
@@ -182,6 +181,7 @@ class Gdal2 < Formula
       sde
       rasdaman
       sosi
+      podofo
     ]
     args.concat unsupported_backends.map { |b| "--without-" + b } if build.without? "unsupported"
 


### PR DESCRIPTION
I couldn't get PDF support to work when installing the gdal2 formula using `--with-complete`.  When running any gdal command, such as `gdalinfo`, the software would immediately write `ERROR 1: Invalid PDF : poPageDict == NULL` to STDOUT and quit.

Looking through the formula, I noticed a comment on lines 165-166:

> Podofo is disabled because Poppler provides the same functionality and then some.

This comment didn't seem to match up with the code though, since pdofo wasn't listed in the unsupported_backends list below it.  In fact, podofo was listed in the supported backends list and also listed as a homebrew dependency.  When I made the changes described in this PR's diff (effectively removing podofo and passing `--with-poppler` to gdal's configure script), PDF support started working!