### PR TITLE
Change "homebrew/science/armadillo" to plain "armadillo"

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -58,7 +58,7 @@ class Gdal2 < Formula
 
   depends_on "ogdi" => :optional
 
-  depends_on "homebrew/science/armadillo" if build.with? "armadillo"
+  depends_on "armadillo" if build.with? "armadillo"
 
   depends_on "osgeo/osgeo4mac/libkml-dev" if build.with? "libkml"
 


### PR DESCRIPTION
This is in response to a deprecation warning:

```
Warning: Use armadillo instead of deprecated homebrew/science/armadillo
```