### PR TITLE
saga-gis-lts: fix sha256 mismatch

### DIFF
--- a/Formula/saga-gis-lts.rb
+++ b/Formula/saga-gis-lts.rb
@@ -8,7 +8,7 @@ class SagaGisLts < Formula
 
   bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
-    sha256 "427ddaa1c2cfa1c9d2040909996d9a3fcf78dff3bc9fe5247814bc9528b3d192" => :sierra
+    sha256 "7ee89e2c199e70d5a630c5ec47efc044c74853c02cb4e57c52f5b22029207a7c" => :sierra
     sha256 "427ddaa1c2cfa1c9d2040909996d9a3fcf78dff3bc9fe5247814bc9528b3d192" => :high_sierra
   end
 


### PR DESCRIPTION
Probably the same for the `high_sierra`bottle.

See

```
Installing osgeo/osgeo4mac/saga-gis-lts
==> Downloading https://osgeo4mac.s3.amazonaws.com/bottles/saga-gis-lts-2.3.1.sierra.bottle.tar.gz
Error: SHA256 mismatch
Expected: 427ddaa1c2cfa1c9d2040909996d9a3fcf78dff3bc9fe5247814bc9528b3d192
Actual: 7ee89e2c199e70d5a630c5ec47efc044c74853c02cb4e57c52f5b22029207a7c
Archive: /Users/travis/Library/Caches/Homebrew/saga-gis-lts-2.3.1.sierra.bottle.tar.gz
```