### PR TITLE
encoded url for people with whitespaces in the cache-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/Formula/mrsid-sdk.rb
+++ b/Formula/mrsid-sdk.rb
@@ -1,9 +1,14 @@
 require File.expand_path("../../Strategies/cache-download", Pathname.new(__FILE__).realpath)
+#require 'shellwords'
+require 'open-uri'
 
 class MrsidSdk < Formula
   desc "MrSID format decoder libs for MG4 (raster and LiDAR), MG3, MG2, JP2"
   homepage "https://www.lizardtech.com/developer/"
-  url "file://#{HOMEBREW_CACHE}/MrSID_DSDK-9.5.1.4427-darwin14.universal.clang60.tar.gz",
+  escapedurl = URI::encode("file://#{HOMEBREW_CACHE}/MrSID_DSDK-9.5.1.4427-darwin14.universal.clang60.tar.gz")
+  opoo escapedurl
+  #url "file://#{HOMEBREW_CACHE}/MrSID_DSDK-9.5.1.4427-darwin14.universal.clang60.tar.gz",
+  url escapedurl,
       :using => CacheDownloadStrategy
   version "9.5.1.4427"
   sha256 "286843f4a22845835a06626327eed67216e403a54e17d8b10a675663d41b9829"

--- a/Formula/mrsid-sdk.rb
+++ b/Formula/mrsid-sdk.rb
@@ -1,14 +1,10 @@
 require File.expand_path("../../Strategies/cache-download", Pathname.new(__FILE__).realpath)
-#require 'shellwords'
 require 'open-uri'
 
 class MrsidSdk < Formula
   desc "MrSID format decoder libs for MG4 (raster and LiDAR), MG3, MG2, JP2"
   homepage "https://www.lizardtech.com/developer/"
-  escapedurl = URI::encode("file://#{HOMEBREW_CACHE}/MrSID_DSDK-9.5.1.4427-darwin14.universal.clang60.tar.gz")
-  opoo escapedurl
-  #url "file://#{HOMEBREW_CACHE}/MrSID_DSDK-9.5.1.4427-darwin14.universal.clang60.tar.gz",
-  url escapedurl,
+  url URI::encode("file://#{HOMEBREW_CACHE}/MrSID_DSDK-9.5.1.4427-darwin14.universal.clang60.tar.gz"),
       :using => CacheDownloadStrategy
   version "9.5.1.4427"
   sha256 "286843f4a22845835a06626327eed67216e403a54e17d8b10a675663d41b9829"


### PR DESCRIPTION
As a temporary fix, so I can tap into the repository (while having a space in my drive name and some rerouting of my home-folder), I added an encoding of the url to the homebrew_cache.

(my former problem: https://github.com/OSGeo/homebrew-osgeo4mac/issues/266)

Don't know if this should be pulled... ?