### PR TITLE
Update gdal2-python.rb

### DIFF
--- a/Formula/gdal2-python.rb
+++ b/Formula/gdal2-python.rb
@@ -63,8 +63,8 @@ class Gdal2Python < Formula
   depends_on "swig" => :build
   depends_on "gdal2"
   depends_on NoGdal2Python
-  depends_on :python => :recommended
-  depends_on :python3 => :recommended
+  depends_on "python@2"
+  depends_on "python"
   depends_on "numpy"
 
   resource "autotest" do


### PR DESCRIPTION
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/gdal2-python.rb:66:in `<class:Gdal2Python>'
Please report this to the osgeo/osgeo4mac tap!

Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/gdal2-python.rb:67:in `<class:Gdal2Python>'
Please report this to the osgeo/osgeo4mac tap!