### PR TITLE
Update pyspatialite.rb

### DIFF
--- a/Formula/pyspatialite.rb
+++ b/Formula/pyspatialite.rb
@@ -26,7 +26,7 @@ class Pyspatialite < Formula
     sha256 "ec55ca6b391698248bb0caca31aac13ad5441b632065ea8a9a0693d77b7d7565" => :high_sierra
   end
 
-  depends_on :python
+  depends_on "python@2"
   depends_on "geos"
   depends_on "proj"
   depends_on "sqlite"


### PR DESCRIPTION
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/pyspatialite.rb:29:in `<class:Pyspatialite>'
Please report this to the osgeo/osgeo4mac tap!