### PR TITLE
Update qca-qt4.rb

### DIFF
--- a/Formula/qca-qt4.rb
+++ b/Formula/qca-qt4.rb
@@ -40,7 +40,7 @@ class QcaQt4 < Formula
   depends_on "openssl" # qca-ossl
   depends_on "botan" => :optional # qca-botan
   depends_on "libgcrypt" => :optional # qca-gcrypt
-  depends_on :gpg => [:optional, :run] # qca-gnupg
+  depends_on "gnupg"
   depends_on "nss" => :optional # qca-nss
   depends_on "pkcs11-helper" => :optional # qca-pkcs11
 


### PR DESCRIPTION
Warning: Calling 'depends_on :gpg' is deprecated!
Use 'depends_on "gnupg"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/qca-qt4.rb:43:in `<class:QcaQt4>'
Please report this to the osgeo/osgeo4mac tap!