### PR TITLE
Update pyqt5-webkit.rb

### DIFF
--- a/Formula/pyqt5-webkit.rb
+++ b/Formula/pyqt5-webkit.rb
@@ -16,8 +16,8 @@ class Pyqt5Webkit < Formula
   depends_on "osgeo/osgeo4mac/qt5-webkit"
   depends_on "sip"
   depends_on "pyqt"
-  depends_on :python => :recommended
-  depends_on :python3 => :recommended
+  epends_on "python@2"
+  depends_on "python"
 
   def install
     if build.without?("python3") && build.without?("python")

--- a/Formula/pyqt5-webkit.rb
+++ b/Formula/pyqt5-webkit.rb
@@ -16,7 +16,7 @@ class Pyqt5Webkit < Formula
   depends_on "osgeo/osgeo4mac/qt5-webkit"
   depends_on "sip"
   depends_on "pyqt"
-  epends_on "python@2"
+  depends_on "python@2"
   depends_on "python"
 
   def install


### PR DESCRIPTION
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/pyqt5-webkit.rb:19:in `<class:Pyqt5Webkit>'
Please report this to the osgeo/osgeo4mac tap!

Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/pyqt5-webkit.rb:20:in `<class:Pyqt5Webkit>'
Please report this to the osgeo/osgeo4mac tap!

Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/pyqt5-webkit.rb:19:in `<class:Pyqt5Webkit>'
Please report this to the osgeo/osgeo4mac tap!

Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/pyqt5-webkit.rb:20:in `<class:Pyqt5Webkit>'
Please report this to the osgeo/osgeo4mac tap!