### PR TITLE
Update grass7.rb

### DIFF
--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -44,11 +44,11 @@ class Grass7 < Formula
   depends_on "libtiff"
   depends_on "unixodbc"
   depends_on "fftw"
-  depends_on :python
+  ddepends_on "python@2"
   depends_on "numpy"
   depends_on "wxpython"
-  depends_on :postgresql => :optional
-  depends_on :mysql => :optional
+  depends_on "postgresql"
+  depends_on "mysql"
   depends_on "cairo"
   depends_on "ghostscript" # for cartographic composer previews
   depends_on :x11 # needs to find at least X11/include/GL/gl.h

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -44,7 +44,7 @@ class Grass7 < Formula
   depends_on "libtiff"
   depends_on "unixodbc"
   depends_on "fftw"
-  ddepends_on "python@2"
+  depends_on "python@2"
   depends_on "numpy"
   depends_on "wxpython"
   depends_on "postgresql"


### PR DESCRIPTION
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/grass7.rb:47:in `<class:Grass7>'
Please report this to the osgeo/osgeo4mac tap!

Warning: Calling 'depends_on :postgresql' is deprecated!
Use 'depends_on "postgresql"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/grass7.rb:50:in `<class:Grass7>'
Please report this to the osgeo/osgeo4mac tap!

Warning: Calling 'depends_on :mysql' is deprecated!
Use 'depends_on "mysql"' instead.
/usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/grass7.rb:51:in `<class:Grass7>'
Please report this to the osgeo/osgeo4mac tap!