### PR TITLE
Update to QGIS 2.18.17

### DIFF
--- a/Formula/qgis2.rb
+++ b/Formula/qgis2.rb
@@ -9,8 +9,8 @@ class Qgis2 < Formula
   head "https://github.com/qgis/QGIS.git", :branch => "release-2_18"
 
   stable do
-    url "https://github.com/qgis/QGIS/archive/final-2_18_14.tar.gz"
-    sha256 "f8912cddca6673b54fcbea8b418d877b51d7229ebd4caec07bdb5fbfda6851e4"
+    url "https://github.com/qgis/QGIS/archive/final-2_18_17.tar.gz"
+    sha256 "1d031fbe287c90aa4a90499e83200261b7d38844838c5dd6660e2ce6e9f29d88"
 
     # patches that represent all backports to release-2_18 branch, since release tag
     # see: https://github.com/qgis/QGIS/commits/release-2_18


### PR DESCRIPTION
I just update to the last version of QGIS 2. 
Frist time I've done something similar perhaps I've done some mistake, but it compiles. 

```sh 

The following Python modules are needed by QGIS during run-time:

    matplotlib

You can install manually, via installer package or with `pip` (if availble):

    pip install <module>  OR  pip-2.7 install <module>


If you have built GRASS 6.4.x or 7.0.x support for the Processing plugin set
the following in QGIS:
  Processing->Options: Providers->GRASS commands->GRASS folder to:
     /usr/local/opt/grass6/grass-base
  Processing->Options: Providers->GRASS GIS 7 commands->GRASS 7 folder to:
     /usr/local/opt/grass7/grass-base
```
