### PR TITLE
Fix depends_on syntax for grass7

### DIFF
--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -51,7 +51,7 @@ class Grass7 < Formula
   depends_on "mysql" => :optional
   depends_on "cairo"
   depends_on "ghostscript" # for cartographic composer previews
-  depends_on "x11" # needs to find at least X11/include/GL/gl.h
+  depends_on: x11 # needs to find at least X11/include/GL/gl.h
   depends_on "openblas" => :optional
   depends_on "osgeo/osgeo4mac/liblas-gdal2" if build.with? "liblas"
   depends_on "netcdf" => :optional

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -51,7 +51,7 @@ class Grass7 < Formula
   depends_on "mysql" => :optional
   depends_on "cairo"
   depends_on "ghostscript" # for cartographic composer previews
-  depends_on: x11 # needs to find at least X11/include/GL/gl.h
+  depends_on :x11 # needs to find at least X11/include/GL/gl.h
   depends_on "openblas" => :optional
   depends_on "osgeo/osgeo4mac/liblas-gdal2" if build.with? "liblas"
   depends_on "netcdf" => :optional

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -44,14 +44,14 @@ class Grass7 < Formula
   depends_on "libtiff"
   depends_on "unixodbc"
   depends_on "fftw"
-  depends_on :python
+  depends_on "python@2"
   depends_on "numpy"
   depends_on "wxpython"
-  depends_on :postgresql => :optional
-  depends_on :mysql => :optional
+  depends_on "postgresql" => :optional
+  depends_on "mysql" => :optional
   depends_on "cairo"
   depends_on "ghostscript" # for cartographic composer previews
-  depends_on :x11 # needs to find at least X11/include/GL/gl.h
+  depends_on "x11" # needs to find at least X11/include/GL/gl.h
   depends_on "openblas" => :optional
   depends_on "osgeo/osgeo4mac/liblas-gdal2" if build.with? "liblas"
   depends_on "netcdf" => :optional
@@ -194,7 +194,7 @@ index cf16788..8c0007b 100644
 @@ -114,11 +114,6 @@ real-install: | $(INST_DIR) $(UNIX_BIN)
  	-$(INSTALL) config.status $(INST_DIR)/config.status
  	-$(CHMOD) -R a+rX $(INST_DIR) 2>/dev/null
- 
+
 -ifneq ($(findstring darwin,$(ARCH)),)
 -	@# enable OSX Help Viewer
 -	@/bin/ln -sfh "$(INST_DIR)/docs/html" /Library/Documentation/Help/GRASS-$(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR)
@@ -202,4 +202,4 @@ index cf16788..8c0007b 100644
 -
  $(INST_DIR) $(UNIX_BIN):
  	$(MAKE_DIR_CMD) $@
- 
+

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -54,7 +54,7 @@ for f in ${CHANGED_FORMULAE};do
   if [ "$(echo ${deps} | grep -c 'python')" != "0" ];then
     echo "Installing and configuring Homebrew Python"
     # Already installed, upgrade, if necessary
-    brew outdated python@2 || brew upgrade python@2
+    brew outdated python || brew upgrade python
 
     # Set up Python .pth files
     # get python short version (major.minor)

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -54,7 +54,7 @@ for f in ${CHANGED_FORMULAE};do
   if [ "$(echo ${deps} | grep -c 'python')" != "0" ];then
     echo "Installing and configuring Homebrew Python"
     # Already installed, upgrade, if necessary
-    brew outdated python || brew upgrade python
+    brew outdated python@2 || brew upgrade python@2
 
     # Set up Python .pth files
     # get python short version (major.minor)


### PR DESCRIPTION
This is very similar to #323 but has a few differences:

- Incorporates CI fix from #332 
- keeps `optional` arguments so as to be a more conservative change
- makes the same update for the x11 dependency.  I haven't seen warnings about that one, but since the syntax is exactly the same I assume it will be affected by the same deprecation

If this is helpful, I'm happy to go through and make the equivalent syntax changes in all the other formulae to which they would apply.  Let me know if you would prefer individual small PRs or one combined PR that bundles them all together.