### PR TITLE
Modify Python installation order

### DIFF
--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -51,37 +51,18 @@ for f in ${CHANGED_FORMULAE};do
   deps=$(brew deps -1 --include-build ${f})
   echo "${f} dependencies: ${deps}"
 
-  if [ "$(echo ${deps} | grep -c 'python')" != "0" ];then
-    echo "Installing and configuring Homebrew Python"
-    # Already installed, upgrade, if necessary
-    brew outdated python@2 || brew upgrade python@2
-
-    # Set up Python .pth files
-    # get python short version (major.minor)
-    PY_VER=$(${HOMEBREW_PREFIX}/bin/python2 -c "import sys;print('{0}.{1}'.format(sys.version_info[0],sys.version_info[1]).strip())")
-    mkdir -p ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages
-    echo 'import site; site.addsitedir("${HOMEBREW_PREFIX}/lib/python${PY_VER}/site-packages")' \
-      >> ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages/homebrew.pth
-    echo 'import site; site.addsitedir("${HOMEBREW_PREFIX}/opt/gdal2/lib/python${PY_VER}/site-packages")' \
-      >> ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages/gdal2.pth
-
-    if [[ "${f}" =~ "gdal2" ]];then
-      echo "Installing GDAL 2 Python dependencies"
-      ${HOMEBREW_PREFIX}/bin/pip2 install numpy
-    fi
-    if [[ "${f}" =~ "qgis" ]];then
-      echo "Installing QGIS Python dependencies for testing"
-      ${HOMEBREW_PREFIX}/bin/pip2 install future mock nose2 numpy psycopg2 pyyaml
-    fi
-  fi
-
+  # Upgrade Python3 to the latest version, before installing Python2. Per the discussion here
+  # https://discourse.brew.sh/t/brew-install-python3-fails/1756/3
   if [ "$(echo ${deps} | grep -c 'python3')" != "0" ];then
     echo "Installing and configuring Homebrew Python3"
-    brew install python3
+    brew outdated python || brew upgrade python
 
     # Set up Python .pth files
     # get python short version (major.minor)
     PY_VER=$(${HOMEBREW_PREFIX}/bin/python3 -c "import sys;print('{0}.{1}'.format(sys.version_info[0],sys.version_info[1]).strip())")
+    if [ -n "${DEBUG_TRAVIS}" ];then
+      echo $PY_VER
+    fi
     mkdir -p ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages
     echo 'import site; site.addsitedir("${HOMEBREW_PREFIX}/lib/python${PY_VER}/site-packages")' \
       >> ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages/homebrew.pth
@@ -89,13 +70,44 @@ for f in ${CHANGED_FORMULAE};do
       >> ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages/gdal2.pth
 
     if [[ "${f}" =~ "gdal2" ]];then
-      echo "Installing GDAL 2 Python dependencies"
+      echo "Installing GDAL 2 Python3 dependencies"
       ${HOMEBREW_PREFIX}/bin/pip3 install numpy
     fi
     if [[ "${f}" =~ "qgis" ]];then
-      echo "Installing QGIS Python dependencies for testing"
+      echo "Installing QGIS Python3 dependencies for testing"
       ${HOMEBREW_PREFIX}/bin/pip3 install future mock nose2 numpy psycopg2 pyyaml
     fi
   fi
 
+  if [ "$(echo ${deps} | grep -c 'python')" != "0" ];then
+    echo "Installing and configuring Homebrew Python2"
+    # If we just upgraded to Python3, install python2, otherwise, update it
+    if [ "$(echo ${deps} | grep -c 'python3')" != "0" ];then
+      brew install python@2
+    else
+      brew outdated python@2 || brew upgrade python@2
+    fi
+
+    # Set up Python .pth files
+    # get python short version (major.minor)
+    PY_VER=$(${HOMEBREW_PREFIX}/bin/python2 -c "import sys;print('{0}.{1}'.format(sys.version_info[0],sys.version_info[1]).strip())")
+    if [ -n "${DEBUG_TRAVIS}" ];then
+      echo $PY_VER
+    fi
+    mkdir -p ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages
+    echo 'import site; site.addsitedir("${HOMEBREW_PREFIX}/lib/python${PY_VER}/site-packages")' \
+      >> ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages/homebrew.pth
+    echo 'import site; site.addsitedir("${HOMEBREW_PREFIX}/opt/gdal2/lib/python${PY_VER}/site-packages")' \
+      >> ${HOME}/Library/Python/${PY_VER}/lib/python/site-packages/gdal2.pth
+
+    if [[ "${f}" =~ "gdal2" ]];then
+      echo "Installing GDAL 2 Python2 dependencies"
+      ${HOMEBREW_PREFIX}/bin/pip2 install numpy
+    fi
+    if [[ "${f}" =~ "qgis" ]];then
+      echo "Installing QGIS Python2 dependencies for testing"
+      ${HOMEBREW_PREFIX}/bin/pip2 install future mock nose2 numpy psycopg2 pyyaml
+    fi
+  fi
 done
+


### PR DESCRIPTION
This allows us to upgrade the existing python install to Python3, and then install Python2, that way both can exist at the same time. Taken from a discussion on the hombrew [discourse](https://discourse.brew.sh/t/brew-install-python3-fails/1756/6).

This also includes a superfluous change to the gdal2-python formula, in order to trigger the travis build.

This should hopefully resolve the issues in #308.