### PR TITLE
HDF4 support

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -67,6 +67,7 @@ class Gdal2 < Formula
   if build.with? "complete"
     # Raster libraries
     depends_on "netcdf" # Also brings in HDF5
+    depends_on "hdf4"
     depends_on "jasper"
     depends_on "webp"
     depends_on "cfitsio"
@@ -81,7 +82,6 @@ class Gdal2 < Formula
 
     # Other libraries
     depends_on "xz" # get liblzma compression algorithm library from XZutils
-    depends_on "json-c"
   end
 
   depends_on :java => ["1.7+", :optional, :build]
@@ -141,8 +141,9 @@ class Gdal2 < Formula
     # Optional Homebrew packages supporting additional formats.
     supported_backends = %w[
       liblzma
-      cfitsio
+      hdf4
       hdf5
+      cfitsio
       netcdf
       jasper
       xerces
@@ -168,7 +169,6 @@ class Gdal2 < Formula
     unsupported_backends = %w[
       gta
       fme
-      hdf4
       fgdb
       ecw
       kakadu
@@ -247,6 +247,9 @@ class Gdal2 < Formula
     ENV.append "CFLAGS", "-I#{sqlite.opt_include}"
 
     ENV.append "LDFLAGS", "-L#{Formula["ogdi"].opt_lib}/ogdi" if build.with? "ogdi"
+
+    # GDAL looks for the renamed hdf4 library, which is an artifact of old builds, so we need to repoint it
+    inreplace "configure", "-ldf", "-lhdf" if build.with? "complete"
 
     # Reset ARCHFLAGS to match how we build.
     ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"

--- a/Formula/hdf4.rb
+++ b/Formula/hdf4.rb
@@ -13,6 +13,10 @@ class Hdf4 < Formula
   depends_on "jpeg"
   depends_on "gcc" if build.with? "fortran"
 
+  bottle do
+
+  end
+
   resource "test_file" do
     url "https://gamma.hdfgroup.org/ftp/pub/outgoing/h4map/data/CT01_Rank6ArraysTablesAttributesGroups.hdf"
     sha256 "e4a610c95ddd1f2247038adf46de354fe902e72b5b72757322d19c362c0d415a"

--- a/Formula/hdf4.rb
+++ b/Formula/hdf4.rb
@@ -1,0 +1,64 @@
+class Hdf4 < Formula
+  homepage "http://www.hdfgroup.org"
+  url "https://support.hdfgroup.org/ftp/HDF/releases/HDF4.2.13/src/hdf-4.2.13.tar.gz"
+  sha256 "be9813c1dc3712c2df977d4960e1f13f20f447dfa8c3ce53331d610c1f470483"
+
+  option "with-fortran", "Build Fortran interface."
+  option "with-tests", "Run the test suite (may fail)"
+
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "szip" => :recommended
+  depends_on "jpeg"
+  depends_on "gcc" if build.with? "fortran"
+
+  def install
+    ENV.O0 # Per the release notes, -O2 can cause memory corruption
+    ENV["SZIP_INSTALL"] = HOMEBREW_PREFIX
+
+    args = std_cmake_args
+    args.concat [
+      "-DBUILD_SHARED_LIBS=ON",
+      "-DHDF4_BUILD_TOOLS=ON",
+      "-DHDF4_BUILD_UTILS=ON",
+      "-DHDF4_BUILD_WITH_INSTALL_NAME=ON",
+      "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON",
+      "-DHDF4_ENABLE_NETCDF=OFF", # Conflict. Just install NetCDF for this.
+      "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
+    ]
+
+    # szip has been reported to break linking with GDAL, so it may need to be disabled if you run into errors.
+    if build.with? "szip"
+      args.concat %W[-DHDF4_ENABLE_SZIP_ENCODING=ON -DHDF4_ENABLE_SZIP_SUPPORT=ON]
+    else
+      args << "-DHDF4_ENABLE_SZIP_SUPPORT=OFF"
+    end
+
+    if build.with? "fortran"
+      args.concat %W[-DHDF4_BUILD_FORTRAN=ON -DCMAKE_Fortran_MODULE_DIRECTORY=#{include}]
+    else
+      args << "-DHDF4_BUILD_FORTRAN=OFF"
+    end
+
+    args << "-DBUILD_TESTING=OFF" if build.without? "tests"
+
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+      system "make", "test" if build.with? "tests"
+
+      # Remove stray nc* artifacts which conflict with NetCDF.
+      rm (bin+"ncdump")
+      rm (bin+"ncgen")
+#      rm (include+"netcdf.inc")
+    end
+  end
+
+  def caveats; <<~EOS
+      HDF4 has been superseeded by HDF5.  However, the API changed
+      substantially and some programs still require the HDF4 libraries in order
+      to function.
+    EOS
+  end
+end

--- a/Formula/hdf4.rb
+++ b/Formula/hdf4.rb
@@ -13,6 +13,11 @@ class Hdf4 < Formula
   depends_on "jpeg"
   depends_on "gcc" if build.with? "fortran"
 
+  resource "test_file" do
+    url "https://gamma.hdfgroup.org/ftp/pub/outgoing/h4map/data/CT01_Rank6ArraysTablesAttributesGroups.hdf"
+    sha256 "e4a610c95ddd1f2247038adf46de354fe902e72b5b72757322d19c362c0d415a"
+  end
+
   def install
     ENV.O0 # Per the release notes, -O2 can cause memory corruption
     ENV["SZIP_INSTALL"] = HOMEBREW_PREFIX
@@ -61,4 +66,11 @@ class Hdf4 < Formula
       to function.
     EOS
   end
+
+  test do
+    resource("test_file").stage do
+      system "#{opt_prefix}/bin/vshow", "CT01_Rank6ArraysTablesAttributesGroups.hdf"
+    end
+  end
+
 end


### PR DESCRIPTION
Addresses the issue brought up in #109. Adds an HDF4 formula and the appropriate backend in GDAL2.

@dschneiderch makes a good point that a lot of data is still in the HDF format and there's currently no support for it in homebrew. The HDF4 formulas were removed from core, science and versions.