### PR TITLE
Fix Travis Python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
       echo "Changed formulae are ${CHANGED_FORMULAE}";
     fi
   - export HOMEBREW_REPOSITORY="$(brew --repo)"
-  - sudo chown -R "$USER" "${HOMEBREW_REPOSITORY}"
+  - sudo chown -R "$USER":admin "${HOMEBREW_REPOSITORY}"
   - git -C "${HOMEBREW_REPOSITORY}" reset --hard origin/master
   - mkdir -p "${HOMEBREW_REPOSITORY}/Library/Taps/${GH_USER}"
   - ln -s "$TRAVIS_BUILD_DIR" "${HOMEBREW_REPOSITORY}/Library/Taps/${TRAVIS_REPO_SLUG}"

--- a/Formula/gdal2-ogdi.rb
+++ b/Formula/gdal2-ogdi.rb
@@ -4,10 +4,10 @@ class Gdal2Ogdi < Formula
   url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
   sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
 
-  # bottle do
-  #   root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
-  #   sha256 "bd40792669fdca893dda8beada60ad513eaac0ef795573a546bcdcab4846546d" => :sierra
-  # end
+   bottle do
+     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
+     sha256 "bd40792669fdca893dda8beada60ad513eaac0ef795573a546bcdcab4846546d" => :sierra
+   end
 
   depends_on "ogdi"
   depends_on "gdal2"

--- a/Formula/gdal2-python.rb
+++ b/Formula/gdal2-python.rb
@@ -57,9 +57,6 @@ class Gdal2Python < Formula
 
   keg_only "older version of gdal is in main tap and installs similar components"
 
-  option "without-python@2", "Build without Python2 support"
-  option "without-python", "Build without Python3 support"
-
   depends_on "swig" => :build
   depends_on "gdal2"
   depends_on NoGdal2Python

--- a/Formula/gdal2-sosi.rb
+++ b/Formula/gdal2-sosi.rb
@@ -4,10 +4,10 @@ class Gdal2Sosi < Formula
   url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
   sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
 
-  # bottle do
-  #   root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
-  #   sha256 "a03417b1bf21b07f450d9554182a23a3c559308cf99c4e9e252ded330fa4f9e4" => :sierra
-  # end
+   bottle do
+     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
+     sha256 "a03417b1bf21b07f450d9554182a23a3c559308cf99c4e9e252ded330fa4f9e4" => :sierra
+   end
 
   depends_on "fyba"
   depends_on "gdal2"

--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -62,7 +62,7 @@ class Gdal2 < Formula
 
   depends_on "armadillo" => :optional
 
-  depends_on "osgeo/osgeo4mac/libkml-dev" if build.with? "libkml"
+  depends_on "libkml-dev" if build.with? "libkml"
 
   if build.with? "complete"
     # Raster libraries

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -39,7 +39,7 @@ class Grass7 < Formula
   if build.with? "gdal-1"
     depends_on "gdal"
   else
-    depends_on "osgeo/osgeo4mac/gdal2"
+    depends_on "gdal2"
   end
   depends_on "libtiff"
   depends_on "unixodbc"

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -39,7 +39,7 @@ class Grass7 < Formula
   if build.with? "gdal-1"
     depends_on "gdal"
   else
-    depends_on "osgeo/osgeo4mac/gdal2"
+    depends_on "gdal2"
   end
   depends_on "libtiff"
   depends_on "unixodbc"
@@ -53,7 +53,7 @@ class Grass7 < Formula
   depends_on "ghostscript" # for cartographic composer previews
   depends_on :x11 # needs to find at least X11/include/GL/gl.h
   depends_on "openblas" => :optional
-  depends_on "osgeo/osgeo4mac/liblas-gdal2" if build.with? "liblas"
+  depends_on "liblas-gdal2" if build.with? "liblas"
   depends_on "netcdf" => :optional
   depends_on "ffmpeg" => :optional
 

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -39,7 +39,7 @@ class Grass7 < Formula
   if build.with? "gdal-1"
     depends_on "gdal"
   else
-    depends_on "gdal2"
+    depends_on "osgeo/osgeo4mac/gdal2"
   end
   depends_on "libtiff"
   depends_on "unixodbc"

--- a/Formula/liblas-gdal2.rb
+++ b/Formula/liblas-gdal2.rb
@@ -7,11 +7,11 @@ class LiblasGdal2 < Formula
 
   head "https://github.com/libLAS/libLAS.git"
 
-  # bottle do
-  #   root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
-  #   sha256 "ffdce4c282c815439a5e2109d7113e6feea3a95a9692f28e464923aa5deef33f" => :sierra
-  #   sha256 "ffdce4c282c815439a5e2109d7113e6feea3a95a9692f28e464923aa5deef33f" => :high_sierra
-  # end
+   bottle do
+     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
+     sha256 "ffdce4c282c815439a5e2109d7113e6feea3a95a9692f28e464923aa5deef33f" => :sierra
+     sha256 "ffdce4c282c815439a5e2109d7113e6feea3a95a9692f28e464923aa5deef33f" => :high_sierra
+   end
 
   keg_only "other version built against older gdal is in main tap"
 

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -116,7 +116,3 @@ done
 
 # Remove any left over lock or stray cache files
 brew cleanup
-# Any lock files?
-find /usr/local/var -name '*.lock'
-echo "Cache"
-find $(brew --cache) -name '*.brewing'

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -53,7 +53,7 @@ for f in ${CHANGED_FORMULAE};do
 
   # Upgrade Python3 to the latest version, before installing Python2. Per the discussion here
   # https://discourse.brew.sh/t/brew-install-python3-fails/1756/3
-  if [ "$(echo ${deps} | grep -c '[python|python3]'" != "0" ];then
+  if [ "$(echo ${deps} | grep -c '[python|python3]')" != "0" ];then
     echo "Installing and configuring Homebrew Python3"
     brew outdated python || brew upgrade python
 
@@ -86,8 +86,8 @@ for f in ${CHANGED_FORMULAE};do
       brew install python@2
     else
       brew outdated python@2 || brew upgrade python@2
-    fi
 
+    fi
     # Set up Python .pth files
     # get python short version (major.minor)
     PY_VER=$(${HOMEBREW_PREFIX}/bin/python2 -c "import sys;print('{0}.{1}'.format(sys.version_info[0],sys.version_info[1]).strip())")

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -116,4 +116,6 @@ done
 
 # Remove any left over lock or stray cache files
 brew cleanup
+# Any lock files?
+ls -lah /usr/local/var/homebrew/locks
 

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -48,7 +48,7 @@ brew update || brew update
 
 for f in ${CHANGED_FORMULAE};do
   echo "Homebrew setup for changed formula ${f}..."
-  deps=$(brew deps -1 --include-build ${f})
+  deps=$(brew deps --include-build ${f})
   echo "${f} dependencies: ${deps}"
 
   # Upgrade Python3 to the latest version, before installing Python2. Per the discussion here

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -113,3 +113,7 @@ for f in ${CHANGED_FORMULAE};do
     fi
   fi
 done
+
+# Remove any left over lock or stray cache files
+brew cleanup
+

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -53,7 +53,7 @@ for f in ${CHANGED_FORMULAE};do
 
   # Upgrade Python3 to the latest version, before installing Python2. Per the discussion here
   # https://discourse.brew.sh/t/brew-install-python3-fails/1756/3
-  if [ "$(echo ${deps} | grep -c 'python3')" != "0" ];then
+  if [ "$(echo ${deps} | grep -c '[python|python3]'" != "0" ];then
     echo "Installing and configuring Homebrew Python3"
     brew outdated python || brew upgrade python
 
@@ -79,10 +79,10 @@ for f in ${CHANGED_FORMULAE};do
     fi
   fi
 
-  if [ "$(echo ${deps} | grep -c 'python')" != "0" ];then
+  if [ "$(echo ${deps} | grep -c 'python@2')" != "0" ];then
     echo "Installing and configuring Homebrew Python2"
     # If we just upgraded to Python3, install python2, otherwise, update it
-    if [ "$(echo ${deps} | grep -c 'python3')" != "0" ];then
+    if [ "$(echo ${deps} | grep -c '[python3|python]')" != "0" ];then
       brew install python@2
     else
       brew outdated python@2 || brew upgrade python@2

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -120,5 +120,3 @@ brew cleanup
 find /usr/local/var -name '*.lock'
 echo "Cache"
 find $(brew --cache) -name '*.brewing'
-echo "Doctor"
-brew doctor

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -117,5 +117,6 @@ done
 # Remove any left over lock or stray cache files
 brew cleanup
 # Any lock files?
-ls -lah /usr/local/var/homebrew/locks
-
+find /usr/local/var -name '*.lock'
+echo "Cache"
+find $(brew --cache) -name '*.brewing'

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -49,7 +49,7 @@ brew update || brew update
 for f in ${CHANGED_FORMULAE};do
   echo "Homebrew setup for changed formula ${f}..."
   deps=$(brew deps --include-build ${f})
-  echo "${f} dependencies: 
+  echo "${f} dependencies:"
   echo "travis_fold:start:deps"
   echo "${deps}"
   echo "travis_fold:end:deps"

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -120,3 +120,5 @@ brew cleanup
 find /usr/local/var -name '*.lock'
 echo "Cache"
 find $(brew --cache) -name '*.brewing'
+echo "Doctor"
+brew doctor

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -49,7 +49,10 @@ brew update || brew update
 for f in ${CHANGED_FORMULAE};do
   echo "Homebrew setup for changed formula ${f}..."
   deps=$(brew deps --include-build ${f})
-  echo "${f} dependencies: ${deps}"
+  echo "${f} dependencies: 
+  echo "travis_fold:start:deps"
+  echo "${deps}"
+  echo "travis_fold:end:deps"
 
   # Upgrade Python3 to the latest version, before installing Python2. Per the discussion here
   # https://discourse.brew.sh/t/brew-install-python3-fails/1756/3
@@ -110,4 +113,3 @@ for f in ${CHANGED_FORMULAE};do
     fi
   fi
 done
-


### PR DESCRIPTION
Building `gdal2-grass7` is currently failing, because the python pre-requesites aren't getting setup correctly.

I think the issue has to do with:
```
  echo "Homebrew setup for changed formula ${f}..."
  deps=$(brew deps -1 --include-build ${f})
  echo "${f} dependencies: ${deps}"
```

The `-1` flag means that when building `gdal2-grass7`, only `gdal2` and `grass7` are listed as dependencies, so the python setup in `before_install.sh` isn't running correctly. This patch simply removes that limitation and gets all the required dependencies, and then does the python things as necessary. 