### PR TITLE
If manual formulae are specified, build only those formulae.

### DIFF
--- a/Formula/pyspatialite.rb
+++ b/Formula/pyspatialite.rb
@@ -20,10 +20,6 @@ class Pyspatialite < Formula
   end
 
   bottle do
-    root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
-    cellar :any
-    sha256 "ec55ca6b391698248bb0caca31aac13ad5441b632065ea8a9a0693d77b7d7565" => :sierra
-    sha256 "ec55ca6b391698248bb0caca31aac13ad5441b632065ea8a9a0693d77b7d7565" => :high_sierra
   end
 
   depends_on "python@2"

--- a/travis/changed_formulas.sh
+++ b/travis/changed_formulas.sh
@@ -5,7 +5,7 @@ set -e
 # manually added by env var. Will not be filtered by skip-formulas.txt
 if [[ -n ${TRAVIS_MANUAL_FORMULAE} ]]; then
   echo "${TRAVIS_MANUAL_FORMULAE}"
-fi
+else
 
 if [[ ! -z  $TRAVIS_PULL_REQUEST_BRANCH  ]]; then
   # if on a PR, just analyze the changed files
@@ -25,3 +25,4 @@ done
 #FORMULAS=$(sed -n -E 's#^Formula/(.+)\.rb$#\1#p' <<< $FILES)
 # skip formulas
 comm -1 -3 travis/skip-formulas.txt <(echo ${FORMULAS} | tr ' ' '\n' )
+fi

--- a/travis/changed_formulas.sh
+++ b/travis/changed_formulas.sh
@@ -3,26 +3,28 @@ set -e
 
 
 # manually added by env var. Will not be filtered by skip-formulas.txt
+# If manual formulae are specified, changed files will be ignored
+# This avoids rebuilding bottles when triggered against master
 if [[ -n ${TRAVIS_MANUAL_FORMULAE} ]]; then
-  echo "${TRAVIS_MANUAL_FORMULAE}"
+	echo "${TRAVIS_MANUAL_FORMULAE}"
 else
 
-if [[ ! -z  $TRAVIS_PULL_REQUEST_BRANCH  ]]; then
-  # if on a PR, just analyze the changed files
-    FILES=$(git diff --diff-filter=AM --name-only $(git merge-base HEAD ${TRAVIS_BRANCH} ) )
-elif [[ ! -z  $TRAVIS_COMMIT_RANGE  ]]; then
-  FILES=$(git diff --diff-filter=AM --name-only ${TRAVIS_COMMIT_RANGE/.../..} )
-else
-  FILES=
-fi
+	if [[ ! -z  $TRAVIS_PULL_REQUEST_BRANCH  ]]; then
+		# if on a PR, just analyze the changed files
+		FILES=$(git diff --diff-filter=AM --name-only $(git merge-base HEAD ${TRAVIS_BRANCH} ) )
+	elif [[ ! -z  $TRAVIS_COMMIT_RANGE  ]]; then
+		FILES=$(git diff --diff-filter=AM --name-only ${TRAVIS_COMMIT_RANGE/.../..} )
+	else
+		FILES=
+	fi
 
-FORMULAS=
-for f in $FILES;do
-  FORMULAS="$FORMULAS $(echo $f | sed -n -E 's#^Formula/(.+)\.rb$#\1#p')"
-done
+	FORMULAS=
+	for f in $FILES;do
+		FORMULAS="$FORMULAS $(echo $f | sed -n -E 's#^Formula/(.+)\.rb$#\1#p')"
+	done
 
-# keep formulas only
-#FORMULAS=$(sed -n -E 's#^Formula/(.+)\.rb$#\1#p' <<< $FILES)
-# skip formulas
-comm -1 -3 travis/skip-formulas.txt <(echo ${FORMULAS} | tr ' ' '\n' )
+	# keep formulas only
+	#FORMULAS=$(sed -n -E 's#^Formula/(.+)\.rb$#\1#p' <<< $FILES)
+	# skip formulas
+	comm -1 -3 travis/skip-formulas.txt <(echo ${FORMULAS} | tr ' ' '\n' )
 fi


### PR DESCRIPTION
@3nids This PR modifies the way the `MANUAL_FORMULAE` variable is handled by travis. Right now, if we manually specify bottles to build, it also builds the most recently changed formulae, which could mean a lot of duplicate work.

This set the bash script to just return the manually specified formulae, if there are any.

This also rebuilds pyspatialite because I needed something to test against.