### PR TITLE
Move new bottle building to Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,5 +87,5 @@ deploy:
 #  upload-dir: bottles
 #  acl: public_read
   on:
-    branch: master
+    branch: bintray
     repo: OSGeo/homebrew-osgeo4mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,5 @@ deploy:
 #  upload-dir: bottles
 #  acl: public_read
   on:
-    # Remove this!
-    branch: bintray
+    branch: master
     repo: OSGeo/homebrew-osgeo4mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,5 +87,5 @@ deploy:
 #  upload-dir: bottles
 #  acl: public_read
   on:
-    branch: bintray
+    branch: master
     repo: OSGeo/homebrew-osgeo4mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,15 +71,22 @@ before_deploy:
 
 deploy:
   skip_cleanup: true
-  provider: s3
-  access_key_id:
-    secure: JxG4/zxgbYvKqX4kJTZdQxvAL+EHqmmi4OEjAOY+KUFAP4t9l5aLEYh6brjHF07kDyFyjMt8G7Hf+SZeznA/JGe8NaliXfCnxLH7ftApCP3l/Tl73z3wXnGL1L7EljiO0EbwlsJUM23B+01BMalzBfyLYOEc61LfSuJsEFFa/ck=
-  secret_access_key:
-    secure: ZdsR1FsY6ER6w6KvF9rjxY4s7GjLXRkT9Rmv4GWyL9+pcHI/4/2KMfab6gj1sQdbc2ocfBgGXR8hQZHi+NZPyTnHbIXf5n2YenLo9NyOHwNs1qiJgxXgtYvhtI/NXCcD9JgX5i5BRR3jkPqJBRe70CmoTwv29kR5Tp158tr3gIg=
-  bucket: osgeo4mac
-  local-dir: bottles
-  upload-dir: bottles
-  acl: public_read
+  provider: bintray
+  file: travis/bintray-upload.json
+  user: nickrobison
+  key:
+    secure: "nEmP/uU8N+TbbX3zWED62CsjPxoDjXcOF3RtAENW/4qVBdI9r7dFmyE4WAW732Ttd1PbANPz7Lz494j2TS2hbn2R4yQ9CuIllsnjey/ve6TAq1FfYSruBuMGLK/7EJ/cSfZWsOBex7b68UeVlvyAra3ck6y9j1ouzF9RKEtCx3P/w3heLN5Fl0pNUCzwknrdBFGfTQRy8NSQnYo/8mpIQbCrXEQThJ4PZY/7s5tqDOv3tAesPTdoGmoNWWBoQe8ZnrwSutskcm6Nsf5nz64i44vai9Xx+9U3QpHDvzuAXOzwxFBGk1dfsnLRp/P71QrDYuqnMEExmfdZAWYK0o0JLuwsecOfSvG2C14fAp1rA2GNWMK9SViYxeYnJgwenGgd7FBci6N052mvyv3+52xGc7aHUlp74PvqYEv8LoILdOlG9jGj1jS41seQyW7Qyg6VYfQ+f1Vp4kUupH3EE53QgJzM6rVyFI9qmkThJTN0ZhUzIhwrTqUfceMkWyeYKd7/hk6AUxhYNZehtR7xH8pf1vibLifUr978M4vyutSwJ4xnaJKTvuUdA0d2GQHAuEDwfqPlYcIUDbKOVmbKj+SifKdSlcwGTYunzmKkJskA9DzYIbUjKe00jluAvjGZuoCIbIKdqlH1ntTUoW5OCpE09TmIZdh/SURRKo7QsfLNQ0I="
+  # S3 bucket upload, which is not working right now
+#  provider: s3
+#  access_key_id:
+#    secure: JxG4/zxgbYvKqX4kJTZdQxvAL+EHqmmi4OEjAOY+KUFAP4t9l5aLEYh6brjHF07kDyFyjMt8G7Hf+SZeznA/JGe8NaliXfCnxLH7ftApCP3l/Tl73z3wXnGL1L7EljiO0EbwlsJUM23B+01BMalzBfyLYOEc61LfSuJsEFFa/ck=
+#  secret_access_key:
+#    secure: ZdsR1FsY6ER6w6KvF9rjxY4s7GjLXRkT9Rmv4GWyL9+pcHI/4/2KMfab6gj1sQdbc2ocfBgGXR8hQZHi+NZPyTnHbIXf5n2YenLo9NyOHwNs1qiJgxXgtYvhtI/NXCcD9JgX5i5BRR3jkPqJBRe70CmoTwv29kR5Tp158tr3gIg=
+#  bucket: osgeo4mac
+#  local-dir: bottles
+#  upload-dir: bottles
+#  acl: public_read
   on:
-    branch: master
+    # Remove this!
+    branch: bintray
     repo: OSGeo/homebrew-osgeo4mac

--- a/travis/before_deploy.sh
+++ b/travis/before_deploy.sh
@@ -54,10 +54,12 @@ BUILT_BOTTLES=
 mkdir -p bottles
 
 pushd bottles
+  # S3 bucket isn't currently working for the Travis pro repo, so we're switching to Bintray, for now.
+  # BOTTLE_ROOT=https://osgeo4mac.s3.amazonaws.com/bottles
+  BOTTLE_ROOT=https://dl.bintray.com/nickrobison/homebrew-osgeo-bottles
   for f in ${CHANGED_FORMULAE};do
     echo "Bottling changed formula ${f}..."
-    brew bottle --verbose --json --root-url=https://osgeo4mac.s3.amazonaws.com/bottles \
-      ${TRAVIS_REPO_SLUG}/${f}
+    brew bottle --verbose --json --root-url=${BOTTLE_ROOT} ${TRAVIS_REPO_SLUG}/${f}
 
     # temporary duplication of 10.2-Xcode-8.x-built bottles to 10.3 bottles
     # Do the bottle duplication per formula, so we can merge the changes

--- a/travis/before_deploy.sh
+++ b/travis/before_deploy.sh
@@ -56,7 +56,7 @@ mkdir -p bottles
 pushd bottles
   # S3 bucket isn't currently working for the Travis pro repo, so we're switching to Bintray, for now.
   # BOTTLE_ROOT=https://osgeo4mac.s3.amazonaws.com/bottles
-  BOTTLE_ROOT=https://dl.bintray.com/nickrobison/homebrew-osgeo-bottles
+  BOTTLE_ROOT=https://dl.bintray.com/homebrew-osgeo/osgeo-bottles
   for f in ${CHANGED_FORMULAE};do
     echo "Bottling changed formula ${f}..."
     brew bottle --verbose --json --root-url=${BOTTLE_ROOT} ${TRAVIS_REPO_SLUG}/${f}

--- a/travis/bintray-upload.json
+++ b/travis/bintray-upload.json
@@ -1,0 +1,24 @@
+{
+  "package": {
+    "name": "bottles",
+    "repo": "homebrew-osgeo-bottles",
+    "subject": "nickrobison",
+    "issue_tracker_url": "https://github.com/OSGeo/homebrew-osgeo4mac/issues",
+    "vcs_url": "https://github.com/OSGeo/homebrew-osgeo4mac.git",
+    "licenses": [
+      "MIT"
+    ],
+    "public_download_numbers": true,
+    "public_stats": true
+  },
+  "version": {
+    "name": "0.1"
+  },
+  "files": [
+    {
+      "includePattern": "bottles/(.*)",
+      "uploadPattern": "$1"
+    }
+  ],
+  "publish": true
+}

--- a/travis/bintray-upload.json
+++ b/travis/bintray-upload.json
@@ -1,8 +1,8 @@
 {
   "package": {
     "name": "bottles",
-    "repo": "homebrew-osgeo-bottles",
-    "subject": "nickrobison",
+    "repo": "osgeo-bottles",
+    "subject": "homebrew-osgeo",
     "issue_tracker_url": "https://github.com/OSGeo/homebrew-osgeo4mac/issues",
     "vcs_url": "https://github.com/OSGeo/homebrew-osgeo4mac.git",
     "licenses": [


### PR DESCRIPTION
This migrates bottle building to a new bintray repository, since S3 doesn't seem to be working with the new travis pro configuration.

Currently, it's using a repository on my own personal organization, but perhaps we can migrate it to a shared organization at some point?

Any existing bottles will remain in S3, which is fine, and hopefully we can move back there once things are working again.

@3nids Does this seem ok to you?
