### PR TITLE
Update gdal2 downstream dependencies to 2.3.0

### DIFF
--- a/Formula/gdal2-ecwjp2.rb
+++ b/Formula/gdal2-ecwjp2.rb
@@ -1,8 +1,8 @@
 class Gdal2Ecwjp2 < Formula
   desc "GDAL/OGR 2.x plugin for ECW driver"
   homepage "http://www.gdal.org/frmt_ecw.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   # bottle do
   #   never

--- a/Formula/gdal2-filegdb.rb
+++ b/Formula/gdal2-filegdb.rb
@@ -1,8 +1,8 @@
 class Gdal2Filegdb < Formula
   desc "GDAL/OGR 2.x plugin for ESRI FileGDB driver"
   homepage "http://www.gdal.org/drv_filegdb.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/Formula/gdal2-grass7.rb
+++ b/Formula/gdal2-grass7.rb
@@ -1,8 +1,8 @@
 class Gdal2Grass7 < Formula
   desc "GDAL/OGR 2.x plugin for GRASS 7"
   homepage "http://www.gdal.org"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-grass-2.2.4.tar.gz"
-  sha256 "7dfe193cd2d7e9cc5dd68d2532b219e18fb2321f25f52969b4039995768b8631"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-grass-2.3.0.tar.gz"
+  sha256 "ca4dae77aa0019236a171f15131836984a82f23cc01d19316961dc62a68ec5c3"
 
   # bottle do
   #   root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/Formula/gdal2-grass7.rb
+++ b/Formula/gdal2-grass7.rb
@@ -1,8 +1,8 @@
 class Gdal2Grass7 < Formula
   desc "GDAL/OGR 2.x plugin for GRASS 7"
   homepage "http://www.gdal.org"
-  url "http://download.osgeo.org/gdal/2.3.0/gdal-grass-2.3.0.tar.gz"
-  sha256 "ca4dae77aa0019236a171f15131836984a82f23cc01d19316961dc62a68ec5c3"
+  url "http://download.osgeo.org/gdal/2.2.4/gdal-grass-2.2.4.tar.gz"
+  sha256 "7dfe193cd2d7e9cc5dd68d2532b219e18fb2321f25f52969b4039995768b8631"
 
   # bottle do
   #   root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/Formula/gdal2-mdb.rb
+++ b/Formula/gdal2-mdb.rb
@@ -10,6 +10,8 @@ class Gdal2Mdb < Formula
 
   depends_on :java
   depends_on "gdal2"
+  depends_on "libtiff"
+  depends_on "libgeotiff"
 
   # various deps needed for configuring
   depends_on "json-c"
@@ -70,10 +72,10 @@ class Gdal2Mdb < Formula
     without_pkgs = %w[
       armadillo bsb cfitsio cryptopp curl dds dods-root
       ecw epsilon expat fgdb fme freexl
-      geos geotiff gif gnm grass grib gta
+      geos gif gnm grass grib gta
       hdf4 hdf5 idb ingres
       j2lura jasper jp2mrsid jpeg jpeg12 kakadu kea
-      libgrass libkml liblzma libtiff libz
+      libgrass libkml liblzma libz
       mongocxx mrf mrsid_lidar mrsid msg mysql netcdf
       oci odbc ogdi opencl openjpeg
       pam pcidsk pcraster pcre perl pg php png python

--- a/Formula/gdal2-mdb.rb
+++ b/Formula/gdal2-mdb.rb
@@ -1,8 +1,8 @@
 class Gdal2Mdb < Formula
   desc "GDAL/OGR 2.x plugin for MDB driver"
   homepage "http://www.gdal.org/drv_mdb.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   # bottle do
   #   never (runtime JAVA version may change too much, or be different from Travis CI)

--- a/Formula/gdal2-mrsid.rb
+++ b/Formula/gdal2-mrsid.rb
@@ -1,8 +1,8 @@
 class Gdal2Mrsid < Formula
   desc "GDAL/OGR 2 plugin for MrSID raster and LiDAR drivers"
   homepage "http://www.gdal.org/frmt_mrsid.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   # bottle do
   #   never

--- a/Formula/gdal2-mysql.rb
+++ b/Formula/gdal2-mysql.rb
@@ -1,8 +1,8 @@
 class Gdal2Mysql < Formula
   desc "GDAL/OGR 2 plugin for MySQL driver"
   homepage "http://www.gdal.org/drv_mysql.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/Formula/gdal2-ogdi.rb
+++ b/Formula/gdal2-ogdi.rb
@@ -1,8 +1,8 @@
 class Gdal2Ogdi < Formula
   desc "GDAL/OGR 2.x plugin for OGDI driver"
   homepage "http://www.gdal.org/drv_ogdi.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
    bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/Formula/gdal2-ogdi.rb
+++ b/Formula/gdal2-ogdi.rb
@@ -44,10 +44,6 @@ class Gdal2Ogdi < Formula
               \\1
               EOS
 
-    inreplace "#{Dir.pwd}/ogr/ogrsf_frmts/ogdi/ogrogdidriver.cpp",
-              /(^CPL_CVSID[^;]+;$)/,
-              "\\1\n\nextern \"C\" void RegisterOGROGDI();\n"
-
     # cxx flags
     args = %W[-Iport -Igcore -Iogr -Iogr/ogrsf_frmts -Iogr/ogrsf_frmts/generic
               -Iogr/ogrsf_frmts/ogdi -I#{ogdi_opt}/include/ogdi]

--- a/Formula/gdal2-oracle.rb
+++ b/Formula/gdal2-oracle.rb
@@ -1,8 +1,8 @@
 class Gdal2Oracle < Formula
   desc "GDAL/OGR 2.x plugin for Oracle Spatial driver"
   homepage "http://www.gdal.org/drv_oci.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   # bottle do
   #   never

--- a/Formula/gdal2-pdf.rb
+++ b/Formula/gdal2-pdf.rb
@@ -26,6 +26,7 @@ class Gdal2Pdf < Formula
     depends_on "jpeg"
     depends_on "libpng"
     depends_on "libtiff"
+    depends_on "libgeotiff"
     depends_on "openjpeg"
   end
   depends_on "pdfium-gdal2" if build.with? "pdfium"
@@ -83,10 +84,10 @@ class Gdal2Pdf < Formula
     without_pkgs = %w[
       armadillo bsb cfitsio cryptopp curl dds dods-root
       ecw epsilon expat fgdb fme freexl
-      geos geotiff gif gnm grass grib gta
+      geos gif gnm grass grib gta
       hdf4 hdf5 idb ingres
       j2lura jasper java jp2mrsid jpeg jpeg12 kakadu kea
-      libgrass libkml liblzma libtiff libz
+      libgrass libkml liblzma libz
       mdb mongocxx mrf mrsid_lidar mrsid msg mysql netcdf
       oci odbc ogdi opencl openjpeg
       pam pcidsk pcraster pcre perl pg php png python

--- a/Formula/gdal2-pdf.rb
+++ b/Formula/gdal2-pdf.rb
@@ -1,8 +1,8 @@
 class Gdal2Pdf < Formula
   desc "GDAL/OGR 2.x plugin for PDF driver"
   homepage "http://www.gdal.org/frmt_pdf.html"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/Formula/gdal2-python.rb
+++ b/Formula/gdal2-python.rb
@@ -46,8 +46,8 @@ class Gdal2Python < Formula
 
   desc "Python bindings for GDAL: Geospatial Data Abstraction Library"
   homepage "https://pypi.python.org/pypi/GDAL"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
   bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"
@@ -72,8 +72,8 @@ class Gdal2Python < Formula
   depends_on "numpy"
 
   resource "autotest" do
-    url "http://download.osgeo.org/gdal/2.2.4/gdalautotest-2.2.4.tar.gz"
-    sha256 "0d3bb1362f86507b255d8e2000b58824b32e9602af893135de549262833bd6aa"
+    url "http://download.osgeo.org/gdal/2.3.0/gdalautotest-2.3.0.tar.gz"
+    sha256 "96df2a320fa2520bffdfc0af663f793d0a0a8d60cfb74b615164eb27b552baaf"
   end
 
   def install

--- a/Formula/gdal2-sosi.rb
+++ b/Formula/gdal2-sosi.rb
@@ -1,8 +1,8 @@
 class Gdal2Sosi < Formula
   desc "GDAL/OGR 2.x plugin for SOSI driver"
   homepage "https://trac.osgeo.org/gdal/wiki/SOSI"
-  url "http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz"
-  sha256 "b9d5a723787f3006a82cb276db171c721187b048b866c0e20e6df464d671a1a4"
+  url "http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz"
+  sha256 "2944bbfee009bf1ca092716e4fd547cb4ae2a1e8816186236110c22f11c7e1e9"
 
    bottle do
     root_url "https://osgeo4mac.s3.amazonaws.com/bottles"

--- a/travis/changed_formulas.sh
+++ b/travis/changed_formulas.sh
@@ -26,5 +26,5 @@ else
 	# keep formulas only
 	#FORMULAS=$(sed -n -E 's#^Formula/(.+)\.rb$#\1#p' <<< $FILES)
 	# skip formulas
-  comm -1 -3 <(travis/skip-formulas.txt | sort -u ) <(echo ${FORMULAS} | tr ' ' '\n' | sort -u )
+  comm -1 -3 <(cat travis/skip-formulas.txt | sort -u ) <(echo ${FORMULAS} | tr ' ' '\n' | sort -u )
 fi

--- a/travis/changed_formulas.sh
+++ b/travis/changed_formulas.sh
@@ -26,5 +26,5 @@ else
 	# keep formulas only
 	#FORMULAS=$(sed -n -E 's#^Formula/(.+)\.rb$#\1#p' <<< $FILES)
 	# skip formulas
-	comm -1 -3 travis/skip-formulas.txt <(echo ${FORMULAS} | tr ' ' '\n' )
+  comm -1 -3 <(travis/skip-formulas.txt | sort -u ) <(echo ${FORMULAS} | tr ' ' '\n' | sort -u )
 fi

--- a/travis/skip-formulas.txt
+++ b/travis/skip-formulas.txt
@@ -1,2 +1,4 @@
 gdal2-ecwjp2
 gpkgtools
+gdal2-oracle
+gdal2-mrsid


### PR DESCRIPTION
The 2nd part of the GDAL update. Finishes up #379.