### PR TITLE
Build shared library for mongo client.

### DIFF
--- a/Formula/mongo-cxx-driver-legacy.rb
+++ b/Formula/mongo-cxx-driver-legacy.rb
@@ -37,6 +37,7 @@ class MongoCxxDriverLegacy < Formula
       "--libc++",
       "--osx-version-min=10.9",
       "--extrapath=#{Formula["boost"].opt_prefix}",
+      "--sharedclient",
       "install"
     ]
 


### PR DESCRIPTION
GDAL requires a shared library, in order to link. So we should build one.