### PR TITLE
gdal2 depends on hdf4 fix

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -71,7 +71,7 @@ class Gdal2 < Formula
   if build.with? "complete"
     # Raster libraries
     depends_on "netcdf" # Also brings in HDF5
-    depends_on "hdf4"
+    depends_on "osgeo/osgeo4mac/hdf4"
     depends_on "jasper"
     depends_on "webp"
     depends_on "cfitsio"


### PR DESCRIPTION
gdal2 wasn’t building because I had more than one formula with the name hdf4

```
==> Upgrading osgeo/osgeo4mac/gdal2 --with-complete --with-opencl --with-armadillo --with-unsupported --with-l
Error: Formulae found in multiple taps:
       * osgeo/osgeo4mac/hdf4
       * brewsci/science/hdf4
```

I don't know if this is reason to fix the formula. 