### PR TITLE
Fix Webkit sandbox and address missing symbols.

### DIFF
--- a/Formula/qt5-webkit.rb
+++ b/Formula/qt5-webkit.rb
@@ -38,8 +38,10 @@ class Qt5Webkit < Formula
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"
-    sha256 "49dbdda9a08a7e3921ad14aa095190e51926e4cef6e11731430a07c6d0395de3" => :sierra
-    sha256 "689dc916f223b50ca697600edb7dcb995dc92fa17740197b1fbb13582a3a21ad" => :high_sierra
+    cellar :any
+    rebuild 1
+    sha256 "e747978ccf022d826d8133ddc15a27f5223ca1a6b2c02d2d61f36c72070a682f" => :high_sierra
+    sha256 "84920602f319187267bd60fdcdad83e94a9c3e89333652595b8a630778547727" => :sierra
   end
 
   keg_only "because Qt5 is keg-only"

--- a/Formula/qt5-webkit.rb
+++ b/Formula/qt5-webkit.rb
@@ -19,7 +19,7 @@ class NoQt5WebKitSandboxRequirement < Requirement
   end
 
   satisfy(:build_env => false) do
-    (ARGV.build_all_from_source? || ARGV.build_from_source? || ARGV.build_bottle?) ? ARGV.no_sandbox? : ARGV.no_sandbox? || pour_bottle?
+    (ARGV.build_from_source?) ? ARGV.no_sandbox? : ARGV.no_sandbox? || pour_bottle?
   end
 
   def message; <<~EOS

--- a/Formula/qt5-webkit.rb
+++ b/Formula/qt5-webkit.rb
@@ -69,7 +69,6 @@ class Qt5Webkit < Formula
 
     mkdir "build" do
       system qt5.bin/"qmake", "../WebKit.pro", *args
-      raise
       system "make"
       # just let it install to qt5 formula prefix
       # NOTE: this violates sandboxing, so --no-sandbox during install required

--- a/Formula/qt5-webkit.rb
+++ b/Formula/qt5-webkit.rb
@@ -19,7 +19,7 @@ class NoQt5WebKitSandboxRequirement < Requirement
   end
 
   satisfy(:build_env => false) do
-    (ARGV.build_from_source?) ? ARGV.no_sandbox? : ARGV.no_sandbox? || pour_bottle?
+    (ARGV.build_all_from_source? || ARGV.build_from_source?) ? ARGV.no_sandbox? : ARGV.no_sandbox? || pour_bottle?
   end
 
   def message; <<~EOS
@@ -54,6 +54,7 @@ class Qt5Webkit < Formula
   depends_on "cmake" => :build
   depends_on "libjpeg"
   depends_on "libpng"
+  depends_on "webp"
 
   def install
     # On Mavericks we want to target libc++, this requires a macx-clang flag.
@@ -68,6 +69,7 @@ class Qt5Webkit < Formula
 
     mkdir "build" do
       system qt5.bin/"qmake", "../WebKit.pro", *args
+      raise
       system "make"
       # just let it install to qt5 formula prefix
       # NOTE: this violates sandboxing, so --no-sandbox during install required

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -56,7 +56,7 @@ for f in ${CHANGED_FORMULAE};do
 
   # Install webkit if it's one of the dependencies
   if [[ "${deps}" =~ "webkit" ]];then
-    echo "Install qt5-webkit without the sandbox"
+    echo "Install qt5-webkit with the sandbox"
     brew install --no-sandbox qt5-webkit
   fi
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -20,7 +20,7 @@ set -e
 for f in ${CHANGED_FORMULAE};do
   echo "Installing dependencies for changed formula ${f}..."
   FLAGS="--only-dependencies --build-bottle"
-  if [[ ${f} =~ "webkit" ]]; then
+  if [[ ${f} == "qt5-webkit" ]]; then
 	FLAGS=${FLAGS}" --no-sandbox"
   fi
 

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -26,7 +26,7 @@ for f in ${CHANGED_FORMULAE};do
   # Default installation flag set
   FLAGS="--build-bottle"
   # Special handling of qt5-webkit
-  if [[ ${f} =~ "webkit" ]]; then
+  if [[ ${f} == "qt5-webkit" ]]; then
 	FLAGS=$FLAGS" --no-sandbox"
   fi
 


### PR DESCRIPTION
Updates the build requirements to remove the need to build all downstream dependencies with the `--no-sandbox` flag. We still need to manually add the flag when building the bottle, because I couldn't find a way to require the sandbox when building from source is an implicit operation, rather than specified by manual arguments. But I think that'll be sufficient for now.

Also addresses the issues noted in #410. There are still some differences in the symbol tables between the Sierra and High Sierra bottles, but I think all the dependencies should be transitively satisfied, so we'll cross that bridge when we come to it.