### PR TITLE
fixing opencv dependency in Orfeo5

### DIFF
--- a/Formula/orfeo5.rb
+++ b/Formula/orfeo5.rb
@@ -51,7 +51,7 @@ class Orfeo5 < Formula
   depends_on "swig" if build.with? "python@2"
   depends_on "fftw" => :optional # restricts built binaries to GPL license
   depends_on "mapnik" => :optional
-  depends_on "brewsci/science/opencv" => :optional
+  depends_on "opencv" => :optional
   depends_on "openjpeg" => :optional
   depends_on "open-mpi" => :optional
   depends_on "brewsci/science/shark" => :optional

--- a/Formula/orfeo5@5.4.rb
+++ b/Formula/orfeo5@5.4.rb
@@ -43,7 +43,7 @@ class Orfeo5AT54 < Formula
   depends_on "swig" if build.with? "python@2"
   depends_on "fftw" => :optional # restricts built binaries to GPL license
   depends_on "mapnik" => :optional
-  depends_on "brewsci/science/opencv" => :optional
+  depends_on "opencv" => :optional
   depends_on "openjpeg" => :optional
 
   # ICE Viewer: needs X11 support


### PR DESCRIPTION
If you use `--with-orfeo5` while installing qgis3 gives an error: 

```sh
Error: No available formula with the name "brewsci/science/opencv"
```

This fix that error. 