### PR TITLE
add zstd compression

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -47,8 +47,6 @@ class Gdal2 < Formula
   depends_on "libpng"
   depends_on "jpeg"
   depends_on "giflib"
-  depends_on "libtiff"
-  depends_on "libgeotiff"
   depends_on "proj"
   depends_on "geos"
   depends_on "json-c"
@@ -126,8 +124,8 @@ class Gdal2 < Formula
       "--with-jpeg=#{HOMEBREW_PREFIX}",
       "--without-jpeg12", # Needs specially configured JPEG and TIFF libraries.
       "--with-gif=#{HOMEBREW_PREFIX}",
-      "--with-libtiff=#{HOMEBREW_PREFIX}",
-      "--with-geotiff=#{HOMEBREW_PREFIX}",
+      "--with-libtiff=internal",
+      "--with-geotiff=internal",
       "--with-sqlite3=#{Formula["sqlite"].opt_prefix}",
       "--with-freexl=#{HOMEBREW_PREFIX}",
       "--with-spatialite=#{HOMEBREW_PREFIX}",

--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -80,6 +80,7 @@ class Gdal2 < Formula
     depends_on "libdap"
     depends_on "libxml2"
     depends_on "openjpeg"
+    depends_on "zstd"
 
     # Vector libraries
     depends_on "unixodbc" # OS X version is not complete enough
@@ -156,6 +157,7 @@ class Gdal2 < Formula
       epsilon
       webp
       openjpeg
+      zstd
     ]
     if build.with? "complete"
       supported_backends.delete "liblzma"
@@ -338,4 +340,3 @@ index 1313bd9974f..5e4e6844d47 100644
 +	if [ -f ".libs/libgdalalljni.dylib" ] ; then \
  		cp .libs/*.dylib . ; \
  	fi
-


### PR DESCRIPTION
This PR adds `ZSTD` compression to gdal2 (gdal>2.3) formula. 

I tested this locally and the install logs looks great. That's said gdal still throw an error when trying ZSTD compression inside geotiff but that might be a configuration problem on my machine 

logs: 
```
$ cat ~/Library/Logs/Homebrew/gdal2/01.configure | grep "zstd"
--with-zstd=/usr/local
checking for ZSTD_decompressStream in -lzstd... yes
```

```
cat ~/Library/Logs/Homebrew/gdal2/01.configure | grep "ZSTD"
checking for ZSTD_decompressStream in -lzstd... yes
  ZSTD support:              yes
```