### PR TITLE
[QGIS3] switch head to master and not release_3-2

### DIFF
--- a/Formula/qgis3.rb
+++ b/Formula/qgis3.rb
@@ -37,7 +37,7 @@ class Qgis3 < Formula
 
   revision 1
 
-  head "https://github.com/qgis/QGIS.git", :branch => "release-3_2"
+  head "https://github.com/qgis/QGIS.git", :branch => "master"
 
   stable do
     url "https://github.com/qgis/QGIS/archive/final-3_2_1.tar.gz"


### PR DESCRIPTION
that would allow to install current master