### PR TITLE
Upgrade remainder of the GDAL stack to 2.3.2

### DIFF
--- a/Formula/gdal2-ecwjp2.rb
+++ b/Formula/gdal2-ecwjp2.rb
@@ -1,8 +1,8 @@
 class Gdal2Ecwjp2 < Formula
   desc "GDAL/OGR 2.x plugin for ECW driver"
   homepage "http://www.gdal.org/frmt_ecw.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   # bottle do
   #   never

--- a/Formula/gdal2-filegdb.rb
+++ b/Formula/gdal2-filegdb.rb
@@ -1,8 +1,8 @@
 class Gdal2Filegdb < Formula
   desc "GDAL/OGR 2.x plugin for ESRI FileGDB driver"
   homepage "http://www.gdal.org/drv_filegdb.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"

--- a/Formula/gdal2-grass7.rb
+++ b/Formula/gdal2-grass7.rb
@@ -1,8 +1,8 @@
 class Gdal2Grass7 < Formula
   desc "GDAL/OGR 2.x plugin for GRASS 7"
   homepage "http://www.gdal.org"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-grass-2.3.1.tar.gz"
-  sha256 "c9a1196f98e8499b4703d6a21f96be01c5d8a69a1154a4fe358704500a88c9b8"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-grass-2.3.2.tar.gz"
+  sha256 "26c2dcff6e668c34455becb379d126715eb70d7f51962c48ba71ea3bdc5f30fa"
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"

--- a/Formula/gdal2-mdb.rb
+++ b/Formula/gdal2-mdb.rb
@@ -1,8 +1,8 @@
 class Gdal2Mdb < Formula
   desc "GDAL/OGR 2.x plugin for MDB driver"
   homepage "http://www.gdal.org/drv_mdb.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   # bottle do
   #   never (runtime JAVA version may change too much, or be different from Travis CI)

--- a/Formula/gdal2-mongodb.rb
+++ b/Formula/gdal2-mongodb.rb
@@ -1,8 +1,8 @@
 class Gdal2Mongodb < Formula
   desc "GDAL/OGR 2.x plugin for MongoDB driver"
   homepage "http://www.gdal.org/drv_mongodb.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"

--- a/Formula/gdal2-mrsid.rb
+++ b/Formula/gdal2-mrsid.rb
@@ -1,8 +1,8 @@
 class Gdal2Mrsid < Formula
   desc "GDAL/OGR 2 plugin for MrSID raster and LiDAR drivers"
   homepage "http://www.gdal.org/frmt_mrsid.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   # bottle do
   #   never

--- a/Formula/gdal2-mysql.rb
+++ b/Formula/gdal2-mysql.rb
@@ -1,8 +1,8 @@
 class Gdal2Mysql < Formula
   desc "GDAL/OGR 2 plugin for MySQL driver"
   homepage "http://www.gdal.org/drv_mysql.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"

--- a/Formula/gdal2-ogdi.rb
+++ b/Formula/gdal2-ogdi.rb
@@ -1,8 +1,8 @@
 class Gdal2Ogdi < Formula
   desc "GDAL/OGR 2.x plugin for OGDI driver"
   homepage "http://www.gdal.org/drv_ogdi.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
    bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"

--- a/Formula/gdal2-oracle.rb
+++ b/Formula/gdal2-oracle.rb
@@ -1,8 +1,8 @@
 class Gdal2Oracle < Formula
   desc "GDAL/OGR 2.x plugin for Oracle Spatial driver"
   homepage "http://www.gdal.org/drv_oci.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   # bottle do
   #   never

--- a/Formula/gdal2-pdf.rb
+++ b/Formula/gdal2-pdf.rb
@@ -1,8 +1,8 @@
 class Gdal2Pdf < Formula
   desc "GDAL/OGR 2.x plugin for PDF driver"
   homepage "http://www.gdal.org/frmt_pdf.html"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"

--- a/Formula/gdal2-python.rb
+++ b/Formula/gdal2-python.rb
@@ -46,8 +46,8 @@ class Gdal2Python < Formula
 
   desc "Python bindings for GDAL: Geospatial Data Abstraction Library"
   homepage "https://pypi.python.org/pypi/GDAL"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
   bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"
@@ -72,8 +72,8 @@ class Gdal2Python < Formula
   depends_on "numpy"
 
   resource "autotest" do
-    url "http://download.osgeo.org/gdal/2.3.1/gdalautotest-2.3.1.tar.gz"
-    sha256 "f4235844ceb6f017d249f32e570e7da090d53b7fc3bfc124aa6b085bdf87ad83"
+    url "http://download.osgeo.org/gdal/2.3.2/gdalautotest-2.3.2.tar.gz"
+    sha256 "e27e7ba2218e4202be66b4b4c4e012d005a03ff44db28d7c603a19da184e8c13"
   end
 
   def install

--- a/Formula/gdal2-sosi.rb
+++ b/Formula/gdal2-sosi.rb
@@ -1,8 +1,8 @@
 class Gdal2Sosi < Formula
   desc "GDAL/OGR 2.x plugin for SOSI driver"
   homepage "https://trac.osgeo.org/gdal/wiki/SOSI"
-  url "http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz"
-  sha256 "034456405d3c43d42643ba68685e4a76da71f040f139d7c57b9a12fbf1378223"
+  url "http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz"
+  sha256 "7808dd7ea7ee19700a133c82060ea614d4a72edbf299dfcb3713f5f79a909d64"
 
    bottle do
     root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"


### PR DESCRIPTION
Second part of upgrading GDAL to 2.3.3, follows up #494.