### PR TITLE
qgis3: it is changed to postgis2

### DIFF
--- a/Formula/qgis3.rb
+++ b/Formula/qgis3.rb
@@ -38,10 +38,10 @@ class Qgis3 < Formula
   homepage "https://www.qgis.org"
   url "https://github.com/qgis/QGIS.git",
     :branch => "release-3_4",
-    :commit => "8965dda3b9331ae7412ee42a120e32d5c5060c5d"
+    :commit => "ec178768e6f8a4723441ba98268dade39c22cd91"
   version "3.4.1"
 
-  revision 1
+  revision 2
 
   head "https://github.com/qgis/QGIS.git", :branch => "master"
 
@@ -118,7 +118,7 @@ class Qgis3 < Formula
   depends_on "libiconv"
   depends_on "geos"
   depends_on "libspatialite"
-  depends_on "postgis"
+  depends_on "postgis2"
   depends_on "openssl"
   depends_on "poppler"
   depends_on "gnu-sed"


### PR DESCRIPTION
@nickrobison First, the bottle of `postgis2` must be built (see https://github.com/OSGeo/homebrew-osgeo4mac/pull/531#issuecomment-440907711)