### PR TITLE
qgis3: removed dependence x11

### DIFF
--- a/Formula/qgis3.rb
+++ b/Formula/qgis3.rb
@@ -38,7 +38,7 @@ class Qgis3 < Formula
   homepage "https://www.qgis.org"
   url "https://github.com/qgis/QGIS.git",
     :branch => "release-3_4",
-    :commit => "ae76c05c9758e7ce4e9bdecf4243721b3ac6208f"
+    :commit => "7f5afe620f10c585231a84752779f0ecf8b3b9e4"
   version "3.4.2"
 
   revision 1
@@ -97,7 +97,6 @@ class Qgis3 < Formula
     depends_on "graphviz" => :build
     depends_on "doxygen" => :build
   end
-  depends_on :x11
   depends_on "qca"
   depends_on "qtkeychain"
   depends_on "qscintilla2"


### PR DESCRIPTION
Solution for the problem reported in #544.

It is only necessary for `grass7`, and it is already in its formula.