### PR TITLE
orfeo6: integrate to qgis3

### DIFF
--- a/Formula/orfeo6.rb
+++ b/Formula/orfeo6.rb
@@ -78,9 +78,7 @@ class Orfeo6 < Formula
     depends_on "qt" => :optional
   end
 
-  depends_on "curl"
-  depends_on "fltk"
-  depends_on "hdf5"
+  depends_on "hdf5" => :optional
   depends_on "open-mpi"
 
   resource "geoid" do


### PR DESCRIPTION
Solution for the problem reported in #431.
Several changes were applied. 
The plugin will be installed in `qgis3` with `--with-orfeo6`
