### PR TITLE
Fix grass7 compilation when liblas is enabled.

### DIFF
--- a/.circleci/before_install.sh
+++ b/.circleci/before_install.sh
@@ -35,6 +35,9 @@ done
 
 brew update || brew update
 
+# Install XQuartz
+brew cask install xquartz
+
 
 for f in ${CHANGED_FORMULAE};do
   echo "Homebrew setup for changed formula ${f}..."

--- a/Formula/grass7.rb
+++ b/Formula/grass7.rb
@@ -75,7 +75,6 @@ class Grass7 < Formula
   depends_on "fontconfig" => :optional
   depends_on "geos" => :optional
   depends_on "lesstif" => :optional
-  depends_on "liblas" => :optional
   depends_on "libomp" => :optional
   depends_on "libpng" => :optional
   depends_on "libpq" => :optional


### PR DESCRIPTION
Should address the issue reported, again, in #507.

It looks like the `liblas` formula from core was added as a dependency, we actually need to use the `liblas-gdal2` formula, since that one links against the `gdal2` formula that we provide.