### PR TITLE
Add WHITEBOKTOOLS formula

### DIFF
--- a/Formula/whitebox-tools.rb
+++ b/Formula/whitebox-tools.rb
@@ -1,0 +1,24 @@
+class WhiteboxTools < Formula
+  desc "Geographic information system (GIS) and remote sensing package intended for advanced geospatial analysis and data visualization"
+  homepage "https://www.uoguelph.ca/~hydrogeo/WhiteboxTools"
+  url "https://github.com/jblindsay/whitebox-tools/releases/download/v0.13/WhiteboxTools_darwin_amd64.zip"
+  sha256 "fe79c3b797ba7ae23a525e11441b0d6406c339858b23271c143734c62af7ec27"
+  # url "https://github.com/jblindsay/whitebox-tools.git",
+  #   :branch => "master",
+  #   :commit => "f0cf6af792de8f60dd8afb10e3f0a26df1c702c4"
+  version "0.13.0"
+
+  # revision 1
+
+  # head "https://github.com/jblindsay/whitebox-tools.git", :branch => "master"
+
+  def install
+    cp_r "#{buildpath}", "#{prefix}"
+    mkdir "#{bin}"
+    ln_s "#{prefix}/WBT/whitebox_tools", "#{bin}/whitebox_tools"
+  end
+
+  test do
+    system "false"
+  end
+end

--- a/Formula/whitebox-tools.rb
+++ b/Formula/whitebox-tools.rb
@@ -1,5 +1,5 @@
 class WhiteboxTools < Formula
-  desc "Geographic information system (GIS) and remote sensing package intended for advanced geospatial analysis and data visualization"
+  desc "An advanced geospatial data analysis platform"
   homepage "https://www.uoguelph.ca/~hydrogeo/WhiteboxTools"
   url "https://github.com/jblindsay/whitebox-tools/releases/download/v0.13/WhiteboxTools_darwin_amd64.zip"
   sha256 "fe79c3b797ba7ae23a525e11441b0d6406c339858b23271c143734c62af7ec27"

--- a/Formula/whitebox-tools.rb
+++ b/Formula/whitebox-tools.rb
@@ -19,6 +19,6 @@ class WhiteboxTools < Formula
   end
 
   test do
-    system "#{bin}/whitebox_tools" --version
+    system "#{bin}/whitebox_tools", "--toolbox=Slope"
   end
 end

--- a/Formula/whitebox-tools.rb
+++ b/Formula/whitebox-tools.rb
@@ -19,6 +19,6 @@ class WhiteboxTools < Formula
   end
 
   test do
-    system "false"
+    system "#{bin}/whitebox_tools" --version
   end
 end


### PR DESCRIPTION
A sample of the program working on `qgis3`.

<img width="1434" alt="whitebox" src="https://user-images.githubusercontent.com/21315242/51292821-f847af80-19ea-11e9-89f8-595450501209.png">

@nickrobison I am preparing other formulas to incorporate more features to `qgis3`.

@luispuerto If you can, write a list of five other functions that we should support.

For example, I have adapted the WBT and TauDEM plugins to be able to use them in `qgis3`.

List of plugins currently supported in qgis3:

- GRASS
- SAGA
- OTB
- R
- TauDEM
- WBT
-  LiDAR - LAStools (soon)