### PR TITLE
qgis: qgis-res is used

### DIFF
--- a/Formula/qgis.rb
+++ b/Formula/qgis.rb
@@ -1,3 +1,9 @@
+################################################################################
+# Maintainer: FJ Perini @fjperini
+# Collaborator: Nick Robison @nickrobison
+# Collaborator: Luis Puerto @lpuerto
+################################################################################
+
 class UnlinkedQGIS < Requirement
   fatal true
 
@@ -32,29 +38,19 @@ class UnlinkedQGIS < Requirement
 end
 
 class Qgis < Formula
-  include Language::Python::Virtualenv
-
   desc "Open Source Geographic Information System"
   homepage "https://www.qgis.org"
   url "https://github.com/qgis/QGIS.git",
     :branch => "release-3_4",
-    :commit => "9eb298fe55f963915dd4e584d1e05bdcbd442755"
+    :commit => "da4a0c09095256c11eff38ef08bc3ca935f40c43"
   version "3.4.4"
 
-  revision 1
+  revision 2
 
   head "https://github.com/qgis/QGIS.git", :branch => "master"
 
   # fix FindQsci and FindPyQt5
   patch :DATA
-
-  bottle do
-    root_url "https://dl.bintray.com/homebrew-osgeo/osgeo-bottles"
-    rebuild 4
-    sha256 "8808c2b5e8e85f00012b111c54aba8dcea9eb8210c12c6aa7b3ba176ee9632d9" => :mojave
-    sha256 "8808c2b5e8e85f00012b111c54aba8dcea9eb8210c12c6aa7b3ba176ee9632d9" => :high_sierra
-    sha256 "8808c2b5e8e85f00012b111c54aba8dcea9eb8210c12c6aa7b3ba176ee9632d9" => :sierra
-  end
 
   def pour_bottle?
     brewed_python?
@@ -62,19 +58,25 @@ class Qgis < Formula
 
   option "without-ninja", "Disable use of ninja CMake generator"
   option "without-pyqt5-webkit", "Build without webkit python bindings"
-  option "with-isolation", "Isolate .app's environment to HOMEBREW_PREFIX, to coexist with other QGIS installs"
   option "without-debug", "Disable debug build, which outputs info to system.log or console"
   option "without-server", "Build without QGIS Server (qgis_mapserv.fcgi)"
+  option "with-server", "Build with QGIS Server (qgis_mapserv.fcgi)"
+  option "with-api-docs", "Build the API documentation with Doxygen and Graphviz"
+  option "with-isolation", "Isolate .app's environment to HOMEBREW_PREFIX, to coexist with other QGIS installs"
   option "without-postgresql", "Build without current PostgreSQL client"
-  option "with-postgresql10", "Build with PostgreSQL 10 client"
+  option "with-postgresql10", "Build with PostgreSQL 10"
   option "with-grass", "Build with GRASS 7 integration plugin and Processing plugin support (or install grass-7x first)"
   option "with-oracle", "Build extra Oracle geospatial database and raster support"
   option "with-orfeo", "Build extra Orfeo Toolbox for Processing plugin"
   option "with-r", "Build extra R for Processing plugin"
   option "with-saga", "Build extra Saga GIS (LTS) for Processing plugin"
+  option "with-gpsbabel", "Build with GPSBabel. Read, write and manipulate GPS waypoints in a variety of formats"
   option "with-qspatialite", "Build QSpatialite Qt database driver"
-  option "with-api-docs", "Build the API documentation with Doxygen and Graphviz"
   option "with-3d", "Build with 3D Map View panel"
+  option "with-lastools", "Build with LAStools: Efficient tools for LiDAR processing"
+  option "with-taudem", "Build with TauDEM: Terrain Analysis Using Digital Elevation Models for hydrology"
+  option "with-whitebox", "Build with Whitebox Tools: An advanced geospatial data analysis platform"
+  option "with-mssql", "Build with Microsoft ODBC Driver for SQL Server"
   # option "with-globe", "Build with Globe plugin, based upon osgEarth"
   # option "with-qt-mysql", "Build extra Qt MySQL plugin for eVis plugin"
 
@@ -87,48 +89,52 @@ class Qgis < Formula
   depends_on "ninja" => [:build, :recommended]
   depends_on "gsl" => :build
   depends_on "sip" => :build
+  depends_on "osgeo/osgeo4mac/six" => :build
   depends_on "bison" => :build
   depends_on "flex" => :build
   depends_on "pkg-config" => :build
   depends_on "python"
   depends_on "qt"
   depends_on "pyqt"
-  depends_on "pyqt5-webkit" => :recommended
+  depends_on "osgeo/osgeo4mac/pyqt5-webkit" => :recommended
   if build.with? "api-docs"
     depends_on "graphviz" => :build
     depends_on "doxygen" => :build
   end
   depends_on "qca"
-  depends_on "qtkeychain"
+  depends_on "osgeo/osgeo4mac/qtkeychain"
   depends_on "qscintilla2"
   depends_on "qwt"
   depends_on "qwtpolar"
   depends_on "qjson"
-  depends_on "sqlite" # keg_only
-  depends_on "expat" # keg_only
+  depends_on "sqlite"
+  depends_on "expat"
   depends_on "proj"
   depends_on "spatialindex"
   depends_on "libpq"
   depends_on "curl"
   depends_on "libzip"
   depends_on "libtasn1"
+  depends_on "desktop-file-utils"
   depends_on "hicolor-icon-theme"
   depends_on "libiconv"
   depends_on "geos"
   depends_on "libspatialite"
-  depends_on "postgis2"
+  depends_on "osgeo/osgeo4mac/postgis2"
   depends_on "openssl"
-  # depends_on "osgqt"
   depends_on "poppler"
   depends_on "gnu-sed"
   depends_on "exiv2"
+  depends_on "numpy"
+  depends_on "brewsci/bio/matplotlib"
+  depends_on "scipy"
+  depends_on "git"
   depends_on "liblas" => :optional
   depends_on "netcdf" => :optional
   depends_on "pdal" => :optional
   depends_on "openvpn" => :optional
   depends_on "szip" => :optional
   depends_on "hdf5" => :optional
-  depends_on "scipy"
 
   # use newer postgresql client than Apple's, also needed by `psycopg2`
   if build.with? "postgresql10"
@@ -137,33 +143,46 @@ class Qgis < Formula
     depends_on "postgresql" => :recommended
   end
 
+  # requires python modules
+  # jinja - MetaSearch
+  # numpy - Processing
+  # owslib - MetaSearch
+  # psycopg2 - DB Manager and Processing
+  # pygments - MetaSearch
+  # yaml - Processing
+  # many useful modules are incorporated
+  depends_on "osgeo/osgeo4mac/qgis-res" => :recommended
+
   if build.with? "server"
     depends_on "fcgi"
     depends_on "spawn-fcgi"
     depends_on "lighttpd"
   end
 
-  # matplotlib
-  depends_on "numpy"
-  depends_on "brewsci/bio/matplotlib"
+  if build.with? "mssql"
+    depends_on "microsoft/mssql-release/msodbcsql17"
+    depends_on "microsoft/mssql-release/mssql-tools"
+  end
 
   # core providers
-  depends_on "gdal2-python"
+  depends_on "osgeo/osgeo4mac/gdal2-python"
 
-  depends_on "oracle-client-sdk" if build.with? "oracle"
   # TODO: add MSSQL third-party support formula?, :optional
+  depends_on "osgeo/osgeo4mac/oracle-client-sdk" if build.with? "oracle"
 
   # core plugins (c++ and python)
   if build.with?("grass") || (HOMEBREW_PREFIX/"opt/grass7").exist?
-    depends_on "grass7"
+    depends_on "osgeo/osgeo4mac/grass7"
     depends_on "gettext"
   end
 
-  # # Not until osgearth is Qt5-ready
+  # the Globe Plugin for QGIS 3 is still not available,
+  # only for QGIS 2 and it does not support a larger version than OSGearh v2.7.
+  # working on the implementation
   # if build.with? "globe"
-  #   # this is pretty borked with OS X >= 10.10+
-  #   depends_on "open-scene-graph"
-  #   depends_on "brewsci/science/osgearth"
+  #   depends_on "osgeo/osgeo4mac/openscenegraph-qt5"
+  #   depends_on "osgeo/osgeo4mac/osgqt"
+  #   depends_on "osgeo/osgeo4mac/osgearth-qt5"
   # end
 
   depends_on "gpsbabel" => :optional
@@ -171,14 +190,15 @@ class Qgis < Formula
   # TODO: remove "pyspatialite" when PyPi package supports spatialite 4.x
   #       or DB Manager supports libspatialite >= 4.2.0 (with mod_spatialite)
   # TODO: what to do for Py3 and pyspatialite?
-  depends_on "pyspatialite" # for DB Manager
+  depends_on "osgeo/osgeo4mac/pyspatialite" # for DB Manager
+
   # depends_on "qt-mysql" => :optional # for eVis plugin (non-functional in 2.x?)
 
   # core processing plugin extras
   # see `grass` above
-  depends_on "orfeo6" => :optional
+  depends_on "osgeo/osgeo4mac/orfeo6" if build.with? "orfeo"
 
-  # If you need R with more support (serfore/r-srf):
+  # R with more support: serfore/r-srf
   # https://github.com/adamhsparks/setup_macOS_for_R
   if build.with?("r")
     unless Formula["r"].opt_prefix.exist?
@@ -186,160 +206,19 @@ class Qgis < Formula
     end
   end
 
-  depends_on "saga-gis-lts" => :optional
+  depends_on "osgeo/osgeo4mac/saga-gis-lts" if build.with? "saga"
+
+  depends_on "osgeo/osgeo4mac/whitebox-tools" if build.with? "whitebox"
+
+  depends_on "osgeo/osgeo4mac/lastools" => :optional
+
+  depends_on "osgeo/osgeo4mac/taudem" => :optional
+
   # TODO: LASTools straight build (2 reporting tools), or via `wine` (10 tools)
   # TODO: Fusion from USFS (via `wine`?)
 
-  # TODO: add one for Py3 (only necessary when macOS ships a Python3 or 3rd-party isolation is needed)
-  resource "pyqgis-startup" do
-    url "https://gist.githubusercontent.com/dakcarto/11385561/raw/e49f75ecec96ed7d6d3950f45ad3f30fe94d4fb2/pyqgis_startup.py"
-    sha256 "385dce925fc2d29f05afd6508bc1f46ec84c0bc607cc0c8dfce78a4bb93b9c4e"
-    version "2.14.0"
-  end
-
-  resource "certifi" do
-    url "https://files.pythonhosted.org/packages/41/b6/4f0cefba47656583217acd6cd797bc2db1fede0d53090fdc28ad2c8e0716/certifi-2018.10.15.tar.gz"
-    sha256 "6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
-  end
-
-  resource "chardet" do
-    url "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz"
-    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
-  end
-
-  resource "idna" do
-    url "https://files.pythonhosted.org/packages/65/c4/80f97e9c9628f3cac9b98bfca0402ede54e0563b56482e3e6e45c43c4935/idna-2.7.tar.gz"
-    sha256 "684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
-  end
-
-  resource "OWSLib" do
-    url "https://files.pythonhosted.org/packages/cc/9c/fd05b20753b0c8a94c225e77c21dfa04a32c9fdbf54001b313bbd0092820/OWSLib-0.17.0.tar.gz"
-    sha256 "ac43839c238ae427d6112709c489decb12218f02d5032ca729e5de7557b5a2df"
-  end
-
-  # dependence for pyproj
-  resource "cython" do
-    url "https://files.pythonhosted.org/packages/f0/66/6309291b19b498b672817bd237caec787d1b18013ee659f17b1ec5844887/Cython-0.29.tar.gz"
-    sha256 "94916d1ede67682638d3cc0feb10648ff14dc51fb7a7f147f4fedce78eaaea97"
-  end
-
-  # fix for Python3.7
-  resource "pyproj" do
-    url "https://github.com/jswhit/pyproj.git",
-      :branch => "master",
-      :commit => "263e283bce209ec7a6e4517828a31839545f2e8a"
-    version "1.9.6"
-  end
-
-  # erro: pip._vendor.pep517.wrappers.BackendUnavailable
-  # disable module temporarily until receive an update.
-  # resource "python-dateutil" do
-  #   url "https://files.pythonhosted.org/packages/0e/01/68747933e8d12263d41ce08119620d9a7e5eb72c876a3442257f74490da0/python-dateutil-2.7.5.tar.gz"
-  #   sha256 "88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
-  # end
-
-  resource "pytz" do
-    url "https://files.pythonhosted.org/packages/cd/71/ae99fc3df1b1c5267d37ef2c51b7d79c44ba8a5e37b48e3ca93b4d74d98b/pytz-2018.7.tar.gz"
-    sha256 "31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca"
-  end
-
-  resource "requests" do
-    url "https://files.pythonhosted.org/packages/40/35/298c36d839547b50822985a2cf0611b3b978a5ab7a5af5562b8ebe3e1369/requests-2.20.1.tar.gz"
-    sha256 "ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz"
-    sha256 "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
-  end
-
-  resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/a5/74/05ffd00b4b5c08306939c485869f5dc40cbc27357195b0a98b18e4c48893/urllib3-1.24.tar.gz"
-    sha256 "41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae"
-  end
-
-  resource "coverage" do
-    url "https://files.pythonhosted.org/packages/fb/af/ce7b0fe063ee0142786ee53ad6197979491ce0785567b6d8be751d2069e8/coverage-4.5.2.tar.gz"
-    sha256 "ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4"
-  end
-
-  resource "funcsigs" do
-    url "https://files.pythonhosted.org/packages/94/4a/db842e7a0545de1cdb0439bb80e6e42dfe82aaeaadd4072f2263a4fbed23/funcsigs-1.0.2.tar.gz"
-    sha256 "a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-  end
-
-  resource "future" do
-    url "https://files.pythonhosted.org/packages/85/aa/ba2e24dcb889d7e98733f87515d80b3512418b80ba79d82d2ddcd43fadf3/future-0.17.0.tar.gz"
-    sha256 "eb6d4df04f1fb538c99f69c9a28b255d1ee4e825d479b9c62fc38c0cf38065a4"
-  end
-
-  resource "mock" do
-    url "https://files.pythonhosted.org/packages/0c/53/014354fc93c591ccc4abff12c473ad565a2eb24dcd82490fae33dbf2539f/mock-2.0.0.tar.gz"
-    sha256 "b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
-  end
-
-  resource "nose2" do
-    url "https://files.pythonhosted.org/packages/1b/c5/d5fcd60f5bf8af1e320fde832d7965933581a9b21b0d1b29bbe2208f4403/nose2-0.8.0.tar.gz"
-    sha256 "9052f2b46807b63d9bdf68e0768da1f8386368889b50043fd5d0889c470258f3"
-  end
-
-  resource "pbr" do
-    url "https://files.pythonhosted.org/packages/33/07/6e68a96ff240a0e7bb1f6e21093532386a98a82d56512e1e3da6d125f7aa/pbr-5.1.1.tar.gz"
-    sha256 "f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68"
-  end
-
-  resource "psycopg2" do
-    url "https://files.pythonhosted.org/packages/c0/07/93573b97ed61b6fb907c8439bf58f09957564cf7c39612cef36c547e68c6/psycopg2-2.7.6.1.tar.gz"
-    sha256 "27959abe64ca1fc6d8cd11a71a1f421d8287831a3262bd4cacd43bbf43cc3c82"
-  end
-
-  resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz"
-    sha256 "3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
-  end
-
-  resource "Jinja2" do
-    url "https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz"
-    sha256 "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
-  end
-
-  resource "MarkupSafe" do
-    url "https://files.pythonhosted.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"
-    sha256 "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
-  end
-
-  resource "Pygments" do
-    url "https://files.pythonhosted.org/packages/71/2a/2e4e77803a8bd6408a2903340ac498cb0a2181811af7c9ec92cb70b0308a/Pygments-2.2.0.tar.gz"
-    sha256 "dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
-  end
-
-  resource "termcolor" do
-    url "https://files.pythonhosted.org/packages/8a/48/a76be51647d0eb9f10e2a4511bf3ffb8cc1e6b14e9e4fab46173aa79f981/termcolor-1.1.0.tar.gz"
-    sha256 "1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
-  end
-
-  resource "oauthlib" do
-    url "https://files.pythonhosted.org/packages/df/5f/3f4aae7b28db87ddef18afed3b71921e531ca288dc604eb981e9ec9f8853/oauthlib-2.1.0.tar.gz"
-    sha256 "ac35665a61c1685c56336bda97d5eefa246f1202618a1d6f34fccb1bdd404162"
-  end
-
-  resource "pyOpenSSL" do
-    url "https://files.pythonhosted.org/packages/9b/7c/ee600b2a9304d260d96044ab5c5e57aa489755b92bbeb4c0803f9504f480/pyOpenSSL-18.0.0.tar.gz"
-    sha256 "6488f1423b00f73b7ad5167885312bb0ce410d3312eb212393795b53c8caa580"
-  end
-
-  resource "httplib2" do
-    url "https://files.pythonhosted.org/packages/fd/ce/aa4a385e3e9fd351737fd2b07edaa56e7a730448465aceda6b35086a0d9b/httplib2-0.11.3.tar.gz"
-    sha256 "e71daed9a0e6373642db61166fa70beecc9bf04383477f84671348c02a04cbdf"
-  end
-
-  resource "numpy" do
-    url "https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip"
-    sha256 "3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7"
-  end
-
   # R Plugin
-  resource "r-app" do
+  resource "r" do
     url "https://github.com/north-road/qgis-processing-r.git",
       :branch => "master",
       :commit => "0fdc3b0ebe39acf1f79103091f155c5a26364850"
@@ -354,36 +233,98 @@ class Qgis < Formula
     version "0.1"
   end
 
-  # Patch: OtbAlgorithmProvider
-  resource "OtbAlgorithmProvider" do
-    url "https://gist.githubusercontent.com/fjperini/009a5dda278c1a10e0758865d149820c/raw/fe1cf1292ecd497fb77b830b59296315295a6615/OtbAlgorithmProvider.patch"
-    sha256 "3b2d8573b8a7a820a73531bc9b0128048faaf9229af619fbd6fa95d02cb63ec2"
+  # WhiteboxTools Plugin
+  resource "whitebox" do
+    url "https://github.com/alexbruy/processing-whitebox.git",
+      :branch => "master",
+      :commit => "5cbd81240e2a4e08fa0df515bf3dbf11957998ea"
+    version "0.9.0"
+  end
+
+  # TauDEM Plugin
+  resource "taudem" do
+    url "https://github.com/alexbruy/processing-taudem.git",
+      :branch => "master",
+      :commit => "38dc454c477b6a6e917f2b3777dc69ed3ecd6062"
+    version "2.0.0"
+  end
+
+  # TauDEM Plugin
+  resource "lastools" do
+    url "https://github.com/rapidlasso/LAStoolsPluginQGIS3.git",
+      :branch => "master",
+      :commit => "5b297ddbc6dab4f5c323d637e284f77809970927"
+    version "1.2"
   end
 
   # Patch: OtbUtils
   resource "OtbUtils" do
-    url "https://gist.githubusercontent.com/fjperini/53f53daf78ab5e203fd81322ea5c3a2f/raw/4838df9a17aa10a77df0285164f517d9fca4e7c6/OtbUtils.patch"
-    sha256 "659e9310c74b3b7615ec7f812061a93e59d838110e7d4ed7697d6657f15a332e"
+    url "https://gist.githubusercontent.com/fjperini/dc45ed0f637ae7dc8ec543a701e012f6/raw/91420d39830c6a3bd74bb2b06a338dee82922e5d/OtbUtils.diff"
+    sha256 "c4d59ca8e29618fd51036fe346dc5bffb3082fdc67bfd682dc4466d11d103fa7"
   end
 
-  # Patch: RAlgorithmProvider
-  resource "RAlgorithmProvider" do
-    url "https://gist.githubusercontent.com/fjperini/bf9fbd1ac9cc2729994cf331baf7a439/raw/855d95c24d5f4df910f8f454cf6b82389f5de820/RAlgorithmProvider.patch"
-    sha256 "254b0341c05f077dbcf67e29c14d77407a765a04d04524915c9443498a3f4343"
+  # Patch: OtbAlgorithmProvider
+  resource "OtbAlgorithmProvider" do
+    url "https://gist.githubusercontent.com/fjperini/d8fe440818814c0800e5071a0ccb4f70/raw/dfb780ae959c801cfde8e71bb6745a0100e48e42/OtbAlgorithmProvider.diff"
+    sha256 "a20f0b2125b5d6572930390020614c9d0da568db16d5f75b32d18231e9215445"
+  end
+
+  # Patch: whiteboxProvider
+  resource "whiteboxProvider" do
+    url "https://gist.githubusercontent.com/fjperini/fcb9f964c5396ab8b72c874a8db41b1d/raw/154deb8f17d52d11f1fba2642d43df2b1d0d936d/whiteboxProvider.diff"
+    sha256 "e95191b38765d6072c1a637e735114cce03d53173e47b96626bb30930b5e9c7f"
+  end
+
+  # Patch: taudemProvider
+  resource "taudemProvider" do
+    url "https://gist.githubusercontent.com/fjperini/1899e20e0286058a74116aecf466f0a0/raw/a2fc2c7a31c747fca5fbed4e885a6503fe6a5d4c/taudemProvider.diff"
+    sha256 "39a494f886d00011a0101b40715d828465592f304590438a7658d03298950cf5"
+  end
+
+  # Patch: taudemUtils
+  resource "taudemUtils" do
+    url "https://gist.githubusercontent.com/fjperini/f3e5ed0e964f4b7ead80a7c39a7115f6/raw/c3c8cca96d51156d0f60fe487b5b848faa3d0c2c/taudemUtils.diff"
+    sha256 "3cf403f74c2ed67f6cdfb87c04cf0b09b085fb9f77ddde9be1d7f2ac12fe53a3"
+  end
+
+  # Patch: LAStoolsProvider
+  resource "LAStoolsProvider" do
+    url "https://gist.githubusercontent.com/fjperini/d6dd9f294be338fba4a05959b845f095/raw/4da2e9e0bd931ad00b3ca66777c3a9d50cde18ba/LAStoolsProvider.diff"
+    sha256 "82656a9fd6f42056d5c2a5487f2429b7f2c66c83287852fb644517abccecc563"
   end
 
   def install
     ENV.cxx11
 
-    printf "\n\033[31mIn case you have installed another version of Python (Anaconda, Miniconda or if you used the installer provided by python.org).\e[0m\n\n"
+    printf "\n\033[31mIn case you have installed another version of Python (Anaconda, Miniconda or if you used the installer provided by python.org).\e[0m\n"
 
-    printf "\e[0mIf the installation failed due to the problem reported in \e[32mhttps://github.com/OSGeo/homebrew-osgeo4mac/issues/520\e[0m\n\n"
+    printf "\033[31mQGIS will use the first Python that is in its PATH, so the installation may fail.\e[0m\n\n"
+
+    printf "If the installation failed due to the problem reported in \e[32mhttps://github.com/OSGeo/homebrew-osgeo4mac/issues/520\e[0m\n\n"
 
     printf "Try after doing:\n\n"
 
-    printf "    $ brew unlink python && brew link --force python\n\n"
+    printf "    \e[32m$ brew unlink python && brew link --force python\e[0m\n\n"
 
-    printf "    $ $PATH (Check that there is no other version)\n\n"
+    printf "    \e[32m$ $PATH (Check that there is no other version)\e[0m\n\n"
+
+    printf "If the installation failed due to the problem reported in \e[32mhttps://github.com/OSGeo/homebrew-osgeo4mac/issues/510\e[0m\n\n"
+
+    printf "Try after doing:\n\n"
+
+    printf "    \e[32m$ brew reinstall ninja gsl sip six bison flex pkg-config python qt pyqt qscintilla2\e[0m\n\n"
+
+    printf "    \e[32m$ brew link --overwrite pyqt\e[0m\n\n"
+
+    printf "Other Notes:\n\n"
+
+    printf "    An installation that failed previously may have created this link\n"
+
+    printf "    \033[31m#{HOMEBREW_PREFIX}/lib/python#{py_ver}/site-packages/PyQt5/uic/widget-plugins/qgis_customwidgets.py\e[0m, you will need to delete it.\n\n"
+
+    printf "    Also make sure that the folder \033[31m#{HOMEBREW_PREFIX}/Cellar/qgis\e[0m does not exist if the installation fails.\n\n"
+
+    printf "    It is also recommended remove the Homebrew Cache \e[32m$ rm -rf $(brew --cache)\e[0m (\e[32m~/Library/Caches/Homebrew\e[0m) and the temporary build files in \e[32m/tmp\e[0m.\n\n\n"
 
     printf "\033[31mThe installation will continue, but remember the above.\e[0m\n"
 
@@ -394,67 +335,98 @@ class Qgis < Formula
 
     printf "\n\n"
 
-    # we proceed to install the plugins as a first step,
+    # proceeds to install the add-ons as a first step,
     # to ensure that the patches are applied
     mkdir "#{prefix}/QGIS.app/Contents/Resources/python/plugins/"
 
-    if build.with?("orfeo") || brewed_orfeo6?
+    if build.with?("orfeo") || brewed_orfeo?
       resource("otb").stage do
         cp_r "./otb", "#{buildpath}/python/plugins/"
       end
-      resource("OtbAlgorithmProvider").stage do
-        cp_r "./OtbAlgorithmProvider.patch", "#{buildpath}"
-      end
       resource("OtbUtils").stage do
-        cp_r "./OtbUtils.patch", "#{buildpath}"
+        cp_r "./OtbUtils.diff", "#{buildpath}"
       end
-      system "patch", "-p1", "-i", "#{buildpath}/OtbAlgorithmProvider.patch"
-      system "patch", "-p1", "-i", "#{buildpath}/OtbUtils.patch"
+      resource("OtbAlgorithmProvider").stage do
+        cp_r "./OtbAlgorithmProvider.diff", "#{buildpath}"
+      end
+      system "patch", "-p1", "-i", "#{buildpath}/OtbUtils.diff"
+      system "patch", "-p1", "-i", "#{buildpath}/OtbAlgorithmProvider.diff"
       cp_r "#{buildpath}/python/plugins/otb", "#{prefix}/QGIS.app/Contents/Resources/python/plugins/"
     end
 
     if build.with?("r") || brewed_r?
-      resource("r-app").stage do
+      resource("r").stage do
         cp_r "./processing_r", "#{prefix}/QGIS.app/Contents/Resources/python/plugins/"
       end
+    end
+
+    if build.with?("whitebox") || brewed_whitebox?
+      resource("whitebox").stage do
+        cp_r "./", "#{buildpath}/python/plugins/processing_whitebox"
+      end
+      resource("whiteboxProvider").stage do
+        cp_r "./whiteboxProvider.diff", "#{buildpath}"
+      end
+      system "patch", "-p1", "-i", "#{buildpath}/whiteboxProvider.diff"
+      cp_r "#{buildpath}/python/plugins/processing_whitebox", "#{prefix}/QGIS.app/Contents/Resources/python/plugins/"
+    end
+
+    if build.with?("taudem") || brewed_taudem?
+      resource("taudem").stage do
+        cp_r "./", "#{buildpath}/python/plugins/processing_taudem"
+      end
+      resource("taudemProvider").stage do
+        cp_r "./taudemProvider.diff", "#{buildpath}"
+      end
+      resource("taudemUtils").stage do
+        cp_r "./taudemUtils.diff", "#{buildpath}"
+      end
+      system "patch", "-p1", "-i", "#{buildpath}/taudemProvider.diff"
+      system "patch", "-p1", "-i", "#{buildpath}/taudemUtils.diff"
+      cp_r "#{buildpath}/python/plugins/processing_taudem", "#{prefix}/QGIS.app/Contents/Resources/python/plugins/"
+    end
+
+    if build.with?("lastools") || brewed_lastools?
+      resource("lastools").stage do
+        cp_r "./LAStools", "#{buildpath}/python/plugins/lastools"
+      end
+      resource("LAStoolsProvider").stage do
+        cp_r "./LAStoolsProvider.diff", "#{buildpath}"
+      end
+      system "patch", "-p1", "-i", "#{buildpath}/LAStoolsProvider.diff"
+      cp_r "#{buildpath}/python/plugins/lastools", "#{prefix}/QGIS.app/Contents/Resources/python/plugins/"
     end
 
     # when gdal2-python.rb loaded, PYTHONPATH gets set to 2.7 site-packages...
     # clear it before calling any local python3 functions
     ENV["PYTHONPATH"] = nil
     if ARGV.debug?
+      puts "brewed_python?: #{brewed_python?}"
+      puts "python_prefix: #{python_prefix}"
       puts "python_exec: #{python_exec}"
       puts "py_ver: #{py_ver}"
-      puts "brewed_python?: #{brewed_python?}"
       puts "python_site_packages: #{python_site_packages}"
-      puts "python_prefix: #{python_prefix}"
+      puts "qgis_site_packages: #{qgis_site_packages}"
       puts "qgis_python_packages: #{qgis_python_packages}"
       puts "gdal_python_packages: #{gdal_python_packages}"
       puts "gdal_python_opt_bin: #{gdal_python_opt_bin}"
       puts "gdal_opt_bin: #{gdal_opt_bin}"
     end
 
-    # install python environment
-    venv = virtualenv_create(libexec/'vendor', "#{HOMEBREW_PREFIX}/opt/python/bin/python3")
-    res = resources.map(&:name).to_set - %w[pyqgis-startup r-app otb OtbAlgorithmProvider OtbUtils RAlgorithmProvider]
-    res.each do |r|
-      venv.pip_install resource(r)
-    end
-
     # set bundling level back to 0 (the default in all versions prior to 1.8.0)
     # so that no time and energy is wasted copying the Qt frameworks into QGIS.
 
-    # Install custom widgets Designer plugin to local qt plugins prefix
+    # install custom widgets Designer plugin to local qt plugins prefix
     mkdir lib/"qt/plugins/designer"
     inreplace "src/customwidgets/CMakeLists.txt",
               "${QT_PLUGINS_DIR}/designer", lib/"qt/plugins/designer".to_s
 
-    # Fix custom widgets Designer module install path
+    # fix custom widgets Designer module install path
     mkdir lib/"python#{py_ver}/site-packages/PyQt5"
     inreplace "CMakeLists.txt",
               "${PYQT5_MOD_DIR}", lib/"python#{py_ver}/site-packages/PyQt5".to_s
 
-    # Install db plugins to local qt plugins prefix
+    # install db plugins to local qt plugins prefix
     if build.with? "qspatialite"
       mkdir lib/"qt/plugins/sqldrivers"
       inreplace "external/qspatialite/CMakeLists.txt",
@@ -492,7 +464,7 @@ class Qgis < Formula
       fcgi
     ].freeze
 
-    # Force CMake to search HB/opt paths first, so headers in HB/include are not found instead;
+    # force CMake to search HB/opt paths first, so headers in HB/include are not found instead;
     # specifically, ensure any gdal v1 includes are not used
     args << "-DCMAKE_PREFIX_PATH=#{cmake_prefixes.map { |f| Formula[f.to_s].opt_prefix }.join(";")}"
 
@@ -526,21 +498,15 @@ class Qgis < Formula
       -DLIBTASN1_INCLUDE_DIR=#{Formula["libtasn1"].opt_include}
       -DLIBTASN1_LIBRARY=#{Formula["libtasn1"].opt_lib}/libtasn1.dylib
 
-      -DQSCINTILLA_INCLUDE_DIR=#{Formula["qscintilla2"].opt_include}
-      -DQSCINTILLA_LIBRARY=#{Formula["qscintilla2"].opt_lib}/libqscintilla2_qt5.dylib
-      -DQSCI_SIP_DIR=#{Formula["qscintilla2"].opt_share}/sip
-      -DPYQT5_SIP_DIR=#{Formula["pyqt"].opt_share}/sip/Qt5
-
       -DPYRCC_PROGRAM=#{libexec}/vendor/bin/pyrcc5
       -DPYUIC_PROGRAM=#{libexec}/vendor/bin/pyuic5
 
-      -DQT_LRELEASE_EXECUTABLE=#{Formula["qt"].opt_bin}/lrelease
       -DWITH_QTWEBKIT=TRUE
+      -DQT_LRELEASE_EXECUTABLE=#{Formula["qt"].opt_bin}/lrelease
+      -DQT5_3DEXTRA_INCLUDE_DIR=#{Formula["qt"].opt_lib}/cmake/Qt53DExtras
       -DQt5WebKitWidgets_DIR=#{Formula["qt5-webkit"].opt_lib}/cmake/Qt5WebKitWidgets
       -DQt5WebKit_DIR=#{Formula["qt5-webkit"].opt_lib}/cmake/Qt5WebKit
 
-      -DENABLE_TESTS=FALSE
-      -DENABLE_MODELTEST=FALSE
       -DWITH_QWTPOLAR=TRUE
       -DWITH_INTERNAL_QWTPOLAR=FALSE
       -DQGIS_MACAPP_BUNDLE=0
@@ -548,33 +514,86 @@ class Qgis < Formula
       -DWITH_QSCIAPI=FALSE
       -DWITH_CUSTOM_WIDGETS=TRUE
       -DWITH_ASTYLE=FALSE
-      -DWITH_GRASS=FALSE
     ]
 
-    # args << "-DAPPLE_APPKIT_LIBRARY=#{ENV['HOME']}/Library/Frameworks/AppKit.framework"
-    # args << "-DAPPLE_APPLICATIONSERVICES_LIBRARY=#{ENV['HOME']}/Library/Frameworks/ApplicationServices.framework"
-    # args << "-DAPPLE_COREFOUNDATION_LIBRARY=#{ENV['HOME']}/Library/Frameworks/CoreFoundation.framework"
-    # args << "-DAPPLE_IOKIT_LIBRARY=#{ENV['HOME']}/Library/Frameworks/IOKit.framework"
+    # Build unit tests
+    args << "-DENABLE_TESTS=FALSE"
+    # Enable QT ModelTest (not for production)
+    args << "-DENABLE_MODELTEST=FALSE"
+    # Perform coverage tests
+    args << "-DENABLE_COVERAGE=FALSE"
+
+    args << "-DSIP_BINARY_PATH=#{Formula["sip"].opt_bin}/sip"
+    args << "-DSIP_DEFAULT_SIP_DIR=#{HOMEBREW_PREFIX}/share/sip"
+    args << "-DSIP_INCLUDE_DIR=#{Formula["sip"].opt_include}"
+    args << "-DSIP_MODULE_DIR=#{Formula["sip"].opt_lib}/python#{py_ver}/site-packages"
+
+    args << "-DPYQT5_MOD_DIR=#{Formula["python"].opt_prefix}/Frameworks/Python.framework/Versions/#{py_ver}/lib/python#{py_ver}/site-packages/PyQt5"
+    args << "-DPYQT5_SIP_DIR=#{HOMEBREW_PREFIX}/share/sip" # Qt5
+    args << "-DPYQT5_BIN_DIR=#{Formula["python"].opt_prefix}/Frameworks/Python.framework/Versions/#{py_ver}/bin"
+    args << "-DPYQT5_SIP_IMPORT=PyQt5.sip"
+    # args << "-DPYQT5_SIP_FLAGS=-n PyQt5.sip -t WS_MACX -t Qt_5_11_2"
+
+    args << "-DQSCI_SIP_DIR=#{Formula["qscintilla2"].opt_share}/sip" # Qsci/qscimod5.sip
+    args << "-DQSCINTILLA_INCLUDE_DIR=#{Formula["qscintilla2"].opt_include}" # Qsci/qsciglobal.h
+    args << "-DQSCINTILLA_LIBRARY=#{Formula["qscintilla2"].opt_lib}/libqscintilla2_qt5.dylib"
 
     # disable CCache
     args << "-DUSE_CCACHE=OFF"
 
+    # Determines whether QGIS core should be built
+    args << "-DWITH_CORE=TRUE"
+
+    # Determines whether QGIS GUI library (and everything built on top of it) should be built
+    args << "-DWITH_GUI=TRUE"
+
+    # Determines whether QGIS analysis library should be built
+    # args << "-DWITH_ANALYSIS=TRUE"
+
+    # Determines whether QGIS desktop should be built
+    args << "-DWITH_DESKTOP=TRUE"
+
+    # Determines whether QGIS Quick library should be built
+    args << "-DWITH_QUICK=FALSE"
+
+    # Determines whether MDAL support should be built
+    args << "-DWITH_INTERNAL_MDAL=TRUE"
+
+    # Determines whether GeoReferencer plugin should be built
+    args << "-DWITH_GEOREFERENCER=TRUE"
+
+    # Determines whether std::thread_local should be used
+    args << "-DWITH_THREAD_LOCAL=TRUE"
+
+    # Determines whether Qt5SerialPort should be tried for GPS positioning
+    # args << "-DWITH_QT5SERIALPORT=TRUE"
+
+    # Use Clang tidy
+    args << "-DWITH_CLANG_TIDY=FALSE"
+
     # By default bindings will be installed only to QGIS directory
     # Someone might want to install it to python site-packages directory
     # as otherwise user has to use PYTHONPATH environment variable to add
-    # args << "-DWITH_BINDINGS=ON"
+    # args << "-DWITH_BINDINGS=TRUE"
+    # Install bindings to global python directory? (might need root)
+    # args << "-DBINDINGS_GLOBAL_INSTALL=FALSE"
+    # Stage-install core Python plugins to run from build directory? (utilities and console are always staged)
+    # args << "-DWITH_STAGED_PLUGINS=TRUE"
+    # Determines whether Python modules in staged or installed locations are byte-compiled"
+    # args << "-DWITH_PY_COMPILE=FALSE"
 
     # python Configuration
-    args << "-DPYTHON_EXECUTABLE='#{`#{HOMEBREW_PREFIX}/opt/python/bin/python3 -c "import sys; print(sys.executable)"`.chomp}'"
+    args << "-DPYTHON_EXECUTABLE='#{`#{Formula["python"].opt_bin}/python3 -c "import sys; print(sys.executable)"`.chomp}'"
 
     # if using Homebrew's Python, make sure its components are always found first
     # see: https://github.com/Homebrew/homebrew/pull/28597
     ENV["PYTHONHOME"] = python_prefix if brewed_python?
 
     # handle custom site-packages for keg-only modules and packages
-    ENV.append_path "PYTHONPATH", python_site_packages
-    # ENV.append_path "PYTHONPATH", qgis_python_packages
-    ENV.append_path "PYTHONPATH", lib/"python#{py_ver}/site-packages"
+    ENV.append_path "PYTHONPATH", "#{python_site_packages}"
+    ENV.append_path "PYTHONPATH", "#{qgis_site_packages}"
+    ENV.append_path "PYTHONPATH", "#{qgis_python_packages}"
+    ENV.append_path "PYTHONPATH", "#{gdal_python_packages}"
 
     # find git revision for HEAD build
     if build.head? && File.exist?("#{cached_download}/.git/index")
@@ -588,51 +607,84 @@ class Qgis < Formula
       # args << "-DUSE_OPENCL=OFF"
     end
 
-    args << "-DWITH_SERVER=#{build.with?("server") ? "TRUE" : "FALSE"}"
-    if build.with? "server"
+    args << "-DWITH_SERVER=#{build.with?("server") || brewed_fcgi? ? "TRUE" : "FALSE"}"
+    if build.with?("server") || brewed_fcgi?
       args << "-DWITH_SERVER_PLUGINS=TRUE"
       fcgi_opt = Formula["fcgi"].opt_prefix
       args << "-DFCGI_INCLUDE_DIR=#{fcgi_opt}/include"
       args << "-DFCGI_LIBRARY=#{fcgi_opt}/lib/libfcgi.dylib"
     end
 
-    args << "-DWITH_POSTGRESQL=#{build.with?("postgresql") ? "TRUE" : "FALSE"}"
-    if build.with? "postgresql"
+    args << "-DWITH_POSTGRESQL=#{build.with?("postgresql") || ("postgresql10") ? "TRUE" : "FALSE"}"
+    if build.with?("postgresql10")
+      args << "-DPOSTGRES_CONFIG=#{Formula["postgresql@10"].opt_bin}/pg_config"
+      args << "-DPOSTGRES_INCLUDE_DIR=#{Formula["postgresql@10"].opt_include}"
+      args << "-DPOSTGRES_LIBRARY=#{Formula["postgresql@10"].opt_lib}/libpq.dylib"
+    else
       args << "-DPOSTGRES_CONFIG=#{Formula["postgresql"].opt_bin}/pg_config"
       args << "-DPOSTGRES_INCLUDE_DIR=#{Formula["postgresql"].opt_include}"
       args << "-DPOSTGRES_LIBRARY=#{Formula["postgresql"].opt_lib}/libpq.dylib"
     end
 
-    args << "-DWITH_GRASS7=#{(build.with?("grass") || brewed_grass7?) ? "TRUE" : "FALSE"}"
-    if build.with?("grass") || brewed_grass7?
+    args << "-DWITH_GRASS7=#{build.with?("grass") || brewed_grass? ? "TRUE" : "FALSE"}"
+    if build.with?("grass") || brewed_grass?
+      args << "-DWITH_GRASS=FALSE" # grass6
       # this is to build the GRASS Plugin, not for Processing plugin support
-      grass7 = Formula["grass7"]
-      args << "-DGRASS_PREFIX7='#{grass7.opt_prefix}/grass-base'"
+      grass = Formula["grass7"]
+      args << "-DGRASS_PREFIX7='#{grass.opt_prefix}/grass-base'"
       # keep superenv from stripping (use Cellar prefix)
-      ENV.append "CXXFLAGS", "-isystem #{grass7.prefix.resolved_path}/grass-base/include"
+      ENV.append "CXXFLAGS", "-isystem #{grass.prefix.resolved_path}/grass-base/include"
       # So that `libintl.h` can be found (use Cellar prefix; should not be needed anymore with QGIS 2.99+)
       # ENV.append "CXXFLAGS", "-isystem #{Formula["gettext"].include.resolved_path}"
     end
 
-    # args << "-DWITH_GLOBE=#{build.with?("globe") ? "TRUE" : "FALSE"}"
-    #   if build.with? "globe"
-    #     osg = Formula["open-scene-graph"]
-    #     osgqt = Formula["osgqt"]
-    #     opoo "`open-scene-graph` formula's keg not linked." unless osg.linked_keg.exist?
-    #     # must be HOMEBREW_PREFIX/lib/osgPlugins-#.#.#, since all osg plugins are symlinked there
-    #     args << "-DOSG_PLUGINS_PATH=#{HOMEBREW_PREFIX}/lib/osgPlugins-#{osg.version}"
-    #     # args << "-DOSGEARTHANNOTATION_LIBRARY=#{osg.opt_lib}"
-    #     # args << "-DOSGEARTHFEATURES_LIBRARY=#{osg.opt_lib}"
-    #     # args << "-DOSGEARTHQT_LIBRARY=#{osg.opt_lib}"
-    #     # args << "-DOSGEARTHSYMBOLOGY_LIBRARY=#{osg.opt_lib}"
-    #     # args << "-DOSGEARTHUTIL_LIBRARY=#{osg.opt_lib}/libosgUtil.dylib"
-    #     args << "-DOSGEARTH_INCLUDE_DIR=#{osg.opt_include}"
-    #     args << "-DOSGEARTH_LIBRARY=#{osg.opt_lib}/libosg.dylib"
-    #     args << "-DOSGQT_LIBRARY=#{osgqt.opt_lib}/libosgQt5.dylib"
+    # args << "-DWITH_GLOBE=#{build.with?("globe") || (brewed_openscenegraph? && brewed_osgqt? && brewed_osgearth?) ? "TRUE" : "FALSE"}"
+    # if build.with?("globe") || (brewed_openscenegraph? && brewed_osgqt? && brewed_osgearth?)
+    #   osg = Formula["openscenegraph-qt5"]
+    #   osgqt = Formula["osgqt"]
+    #   osgearth = Formula["osgearth-qt5"]
+    #   opoo "`openscenegraph-qt5` formula's keg not linked." unless osg.linked_keg.exist?
+    #
+    #   # OSG
+    #   # must be HOMEBREW_PREFIX/lib/osgPlugins-#.#.#, since all osg plugins are symlinked there
+    #   args << "-DOSG_PLUGINS_PATH=#{HOMEBREW_PREFIX}/lib/osgPlugins-#{osg.version}"
+    #   args << "-DOSG_DIR=#{osg.opt_prefix}"
+    #   args << "-DOSG_INCLUDE_DIR=#{osg.opt_include}" # osg/Node
+    #   args << "-DOSG_GEN_INCLUDE_DIR=#{osg.opt_include}" # osg/Config
+    #   args << "-DOSG_LIBRARY=#{osg.opt_lib}/libosg.dylib"
+    #   args << "-DOSGUTIL_LIBRARY=#{osg.opt_lib}/libosgUtil.dylib"
+    #   args << "-DOSGDB_LIBRARY=#{osg.opt_lib}/libosgDB.dylib"
+    #   args << "-DOSGTEXT_LIBRARY=#{osg.opt_lib}/libosgText.dylib"
+    #   args << "-DOSGTERRAIN_LIBRARY=#{osg.opt_lib}/libosgTerrain.dylib"
+    #   args << "-DOSGFX_LIBRARY=#{osg.opt_lib}/libosgFX.dylib"
+    #   args << "-DOSGSIM_LIBRARY=#{osg.opt_lib}/libosgSim.dylib"
+    #   args << "-DOSGVIEWER_LIBRARY=#{osg.opt_lib}/libosgViewer.dylib"
+    #   args << "-DOSGGA_LIBRARY=#{osg.opt_lib}/libosgGA.dylib"
+    #   args << "-DOSGQT_LIBRARY=#{osgqt.opt_lib}/libosgQt5.dylib"
+    #   args << "-DOSGWIDGET_LIBRARY=#{osg.opt_lib}/libosgWidget.dylib"
+    #   args << "-DOPENTHREADS_LIBRARY=#{osg.opt_lib}/libOpenThreads.dylib"
+    #   # args << "-DOPENTHREADS_INCLUDE_DIR=#{osg.opt_include}"
+    #   # args << "-DOSGSHADOW_LIBRARY=#{osg.opt_lib}/libosgShadow.dylib"
+    #   # args << "-DOSGMANIPULATOR_LIBRARY=#{osg.opt_lib}/libosgManipulator.dylib"
+    #   # args << "-DOSGPARTICLE_LIBRARY=#{osg.opt_lib}/libosgParticle.dylib"
+    #
+    #   # OSGEARTH
+    #   args << "-DOSGEARTH_DIR=#{osgearth.opt_prefix}"
+    #   args << "-DOSGEARTH_INCLUDE_DIR=#{osgearth.opt_include}" # osgEarth/TileSource
+    #   args << "-DOSGEARTH_GEN_INCLUDE_DIR=#{osgearth.opt_include}" # osgEarth/Common
+    #   args << "-DOSGEARTH_ELEVATION_QUERY=#{osgearth.opt_include}" # osgEarth/ElevationQuery
+    #   args << "-DOSGEARTH_LIBRARY=#{osgearth.opt_lib}/libosgEarth.dylib"
+    #   args << "-DOSGEARTHUTIL_LIBRARY=#{osgearth.opt_lib}/libosgEarthUtil.dylib"
+    #   args << "-DOSGEARTHFEATURES_LIBRARY=#{osgearth.opt_lib}/libosgEarthFeatures.dylib"
+    #   args << "-DOSGEARTHSYMBOLOGY_LIBRARY=#{osgearth.opt_lib}/libosgEarthSymbology.dylib"
+    #   args << "-DOSGEARTHQT_LIBRARY=#{osgearth.opt_lib}/libosgEarthQt5.dylib"
+    #   args << "-DOSGEARTHANNOTATION_LIBRARY=#{osgearth.opt_lib}/libosgEarthAnnotation.dylib"
+    #
+    #   args << "-DQt5OpenGL_INCLUDE_DIRS=#{Formula["qt"].opt_include}/QtOpenGL"
     # end
 
-    args << "-DWITH_ORACLE=#{build.with?("oracle") ? "TRUE" : "FALSE"}"
-    if build.with? "oracle"
+    args << "-DWITH_ORACLE=#{build.with?("oracle") || brewed_oracle? ? "TRUE" : "FALSE"}"
+    if build.with?("oracle") || brewed_oracle?
       oracle_opt = Formula["oracle-client-sdk"].opt_prefix
       args << "-DOCI_INCLUDE_DIR=#{oracle_opt}/include/oci"
       args << "-DOCI_LIBRARY=#{oracle_opt}/lib/libclntsh.dylib"
@@ -651,7 +703,7 @@ class Qgis < Formula
 
     # prefer opt_prefix for CMake modules that find versioned prefix by default
     # this keeps non-critical dependency upgrades from breaking QGIS linking
-    args << "-DGDAL_CONFIG=#{Formula["gdal2"].opt_bin}gdal-config"
+    args << "-DGDAL_CONFIG=#{Formula["gdal2"].opt_bin}/gdal-config"
     args << "-DGDAL_INCLUDE_DIR=#{Formula["gdal2"].opt_include}"
     args << "-DGDAL_LIBRARY=#{Formula["gdal2"].opt_lib}/libgdal.dylib"
     args << "-DGEOS_CONFIG=#{Formula["geos"].opt_bin}/geos-config"
@@ -671,20 +723,32 @@ class Qgis < Formula
     #   ENV.append "CXX_EXTRA_FLAGS", "-Wno-inconsistent-missing-override"
     # end
 
+    args << "-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations"
+
+    # If set to true, it will disable deprecated functionality to prepare for the next generation of QGIS
+    # args << "-DDISABLE_DEPRECATED=TRUE"
+
+    # Newer versions of UseQt4.cmake include Qt with -isystem automatically
+    # This can be used to force this behavior on older systems
+    # Can be removed as soon as Travis-CI updates from precise
+    # args << "-DSUPPRESS_QT_WARNINGS=TRUE"
+
     ENV.prepend_path "PATH", libexec/"vendor/bin"
+
+    mkdir "#{libexec}/vendor/bin"
 
     # create pyrcc5
     File.open("#{libexec}/vendor/bin/pyrcc5", "w") { |file|
 			file << '#!/bin/sh'
 			file << "\n"
-			file << 'exec python3 -m PyQt5.pyrcc_main ${1+"$@"}'
+			file << 'exec' + " #{Formula["python"].opt_bin}/python3 " + '-m PyQt5.pyrcc_main ${1+"$@"}'
     }
 
     # create pyuic5
     File.open("#{libexec}/vendor/bin/pyuic5", "w") { |file|
 			file << '#!/bin/sh'
 			file << "\n"
-			file << 'exec python3 -m PyQt5.pyuic5_main ${1+"$@"}'
+			file << 'exec' + " #{Formula["python"].opt_bin}/python3 " + '-m PyQt5.pyuic5_main ${1+"$@"}'
     }
 
     chmod("+x", "#{libexec}/vendor/bin/pyrcc5")
@@ -695,6 +759,16 @@ class Qgis < Formula
       system "cmake", "--build", ".", "--target", "all", "--", "-j", Hardware::CPU.cores
       system "cmake", "--build", ".", "--target", "install", "--", "-j", Hardware::CPU.cores
     end
+
+    # link the python modules
+    (prefix/"QGIS.app/Contents/Resources/python").install_symlink Dir["#{Formula["qgis-res"].opt_libexec}/vendor/lib/python#{py_ver}/site-packages/*"]
+    (prefix/"QGIS.app/Contents/Resources/python").install_symlink Dir["#{Formula["sip"].opt_lib}/python#{py_ver}/site-packages/*"]
+    (prefix/"QGIS.app/Contents/Resources/python/PyQt5").install_symlink Dir["#{Formula["pyqt"].opt_lib}/python#{py_ver}/site-packages/PyQt5/*"]
+    (prefix/"QGIS.app/Contents/Resources/python/PyQt5").install_symlink Dir["#{Formula["pyqt5-webkit"].opt_lib}/python#{py_ver}/site-packages/PyQt5/*"]
+    (prefix/"QGIS.app/Contents/Resources/python/PyQt5").install_symlink Dir["#{Formula["qscintilla2"].opt_lib}/python#{py_ver}/site-packages/PyQt5/*"]
+    (prefix/"QGIS.app/Contents/Resources/python").install_symlink Dir["#{Formula["matplotlib"].opt_lib}/python#{py_ver}/site-packages/*"]
+    # (prefix/"QGIS.app/Contents/Resources/python").install_symlink Dir["#{Formula["numpy"].opt_lib}/python#{py_ver}/site-packages/*"]
+    # (prefix/"QGIS.app/Contents/Resources/python").install_symlink Dir["#{Formula["scipy"].opt_lib}/python#{py_ver}/site-packages/*"]
 
     # fixup some errant lib linking
     # TODO: fix upstream in CMake
@@ -717,7 +791,7 @@ class Qgis < Formula
 
     # update .app's bundle identifier, so other installers doesn't get confused
     inreplace prefix/"QGIS.app/Contents/Info.plist",
-              "org.qgis.qgis3", "org.qgis.qgis3-hb#{build.head? ? "-dev" : ""}"
+              "org.qgis.qgis3", "org.qgis.qgis-hb#{build.head? ? "-dev" : ""}"
 
     py_lib = lib/"python#{py_ver}/site-packages"
     py_lib.mkpath
@@ -733,7 +807,7 @@ class Qgis < Formula
     # only works with QGIS > 2.0.1
     # doesn't need executable bit set, loaded by Python runner in QGIS
     # TODO: for Py3
-    libexec.install resource("pyqgis-startup")
+    cp_r "#{Formula["qgis-res"].opt_libexec}/pyqgis_startup.py", "#{libexec}/pyqgis_startup.py"
 
     bin.mkdir
     qgis_bin = bin/name.to_s
@@ -754,8 +828,8 @@ class Qgis < Formula
 
     # define default isolation env vars
     pthsep = File::PATH_SEPARATOR
-    pypth = python_site_packages.to_s
-    pths = %w[/usr/bin /bin /usr/sbin /sbin /opt/X11/bin /usr/X11/bin]
+    pypth = "#{python_site_packages}"
+    pths = %w[/usr/local/bin /usr/local/sbin /usr/bin /bin /usr/sbin /sbin /opt/X11/bin /usr/X11/bin]
 
     unless opts.include?("with-isolation")
       pths = ORIGINAL_PATHS.dup
@@ -765,39 +839,42 @@ class Qgis < Formula
       end
     end
 
-    pths.insert(0, "#{opt_libexec}/vendor/bin")
-
     unless pths.include?(HOMEBREW_PREFIX/"bin")
       pths = pths.insert(0, HOMEBREW_PREFIX/"bin")
     end
 
     # set install's lib/python#{py_ver}/site-packages first, so app will work if unlinked
-    pypths = %W[#{opt_lib}/python#{py_ver}/site-packages #{opt_libexec}/vendor/lib/python#{py_ver}/site-packages #{pypth}]
+    pypths = %W[#{qgis_python_packages} #{qgis_site_packages} #{pypth}]
 
-    pths.insert(0, gdal_opt_bin)
-    pths.insert(0, gdal_python_opt_bin)
-    pypths.insert(0, gdal_python_packages)
+    pths.insert(0, "#{gdal_opt_bin}")
+    pths.insert(0, "#{gdal_python_opt_bin}")
+    pypths.insert(0, "#{gdal_python_packages}")
 
     # prepend qt based utils to PATH (reverse order)
-    pths.insert(0, Formula["qca"].opt_bin.to_s)
-    pths.insert(0, Formula["pyqt"].opt_bin.to_s)
-    pths.insert(0, Formula["sip"].opt_bin.to_s)
-    pths.insert(0, Formula["qt"].opt_bin.to_s)
+    pths.insert(0, "#{Formula["qca"].opt_bin}")
+    pths.insert(0, "#{Formula["pyqt"].opt_bin}")
+    pths.insert(0, "#{Formula["sip"].opt_bin}")
+    pths.insert(0, "#{Formula["qt"].opt_bin}")
 
-    if opts.include?("with-gpsbabel")
-      pths.insert(0, Formula["gpsbabel"].opt_bin.to_s)
+    if opts.include?("with-gpsbabel") || brewed_gpsbabel?
+      pths.insert(0, "#{Formula["gpsbabel"].opt_bin}")
     end
 
     # we need to manually add the saga lts path, since it's keg only
-    if build.with? "saga"
-      pths.insert(0, Formula["saga-gis-lts"].opt_bin.to_s)
+    if opts.include?("with-saga") || brewed_saga?
+      pths.insert(0, "#{Formula["saga-gis-lts"].opt_bin}")
     end
 
     envars = {
       :PATH => pths.join(pthsep),
-      :PYTHONPATH => pypths.join(pthsep),
+      :QGIS_BUNDLE => "#{opt_prefix}/QGIS.app/Contents",
+      :QGIS_PREFIX_PATH => "#{opt_prefix}/QGIS.app/Contents/MacOS",
       :GDAL_DRIVER_PATH => "#{HOMEBREW_PREFIX}/lib/gdalplugins",
       :GDAL_DATA => "#{Formula["gdal2"].opt_share}/gdal",
+      :PYTHONPATH => pypths.join(pthsep),
+      # if it is set, grass it will not work correctly, using Python 2
+      # it will be necessary to wait until it is built with Python 3
+      # :PYTHONHOME =>  "#{Formula["python"].opt_frameworks}/Python.framework/Versions/#{py_ver}",
     }
 
     # handle multiple Qt plugins directories
@@ -815,36 +892,36 @@ class Qgis < Formula
     proc_plugins = "#{app}/Contents/Resources/python/plugins"
     proc_plugins_algs = "#{proc_plugins}/processing/algs"
 
-    if opts.include?("with-grass") || brewed_grass7?
+    if opts.include?("with-grass") || brewed_grass?
       # for core integration plugin support
-      grass7 = Formula["grass7"]
-      envars[:GRASS_PREFIX] = "#{grass7.opt_prefix}/grass-base"
-      # envars[:GRASS_SH] = "/bin/sh"
-      # envars[:GRASS_PROJSHARE] = "#{Formula["proj"].opt_share}"
-      # envars[:GRASS_VERSION] = "7.4.3"
-      # envars[:GRASS_LD_LIBRARY_PATH] = "#{Formula["grass7"].opt_prefix}/grass-#{grass_version}/lib"
-      # envars[:GRASS_PERL] = "#{Formula["perl"].opt_bin}/perl"
+      grass = Formula["grass7"]
+      grass_version = "#{grass.version}"
+      envars[:GRASS_PREFIX] = "#{grass.opt_prefix}/grass-base"
+      envars[:GRASS_SH] = "/bin/sh"
+      envars[:GRASS_PROJSHARE] = "#{Formula["proj"].opt_share}"
+      envars[:GRASS_VERSION] = "#{grass_version}"
+      envars[:GRASS_LD_LIBRARY_PATH] = "#{grass}/grass-#{grass_version}/lib"
+      envars[:GRASS_PERL] = "#{Formula["perl"].opt_bin}/perl"
       begin
         inreplace "#{proc_plugins_algs}/grass7/Grass7Utils.py",
                   "'/Applications/GRASS-7.{}.app/Contents/MacOS'.format(version)",
-                  "'#{grass7.opt_prefix}/grass-base'"
+                  "'#{grass.opt_prefix}/grass-base'"
         puts "GRASS 7 GrassUtils.py has been updated"
         rescue Utils::InreplaceError
         puts "GRASS 7 GrassUtils.py already updated"
       end
     end
 
-    if opts.include?("with-orfeo") || brewed_orfeo6?
-      orfeo6 = Formula["orfeo6"]
-      # envars[:QGIS_PLUGINPATH] = "#{orfeo6.opt_prefix}"
+    if opts.include?("with-orfeo") || brewed_orfeo?
+      orfeo = Formula["orfeo6"]
+      # envars[:QGIS_PLUGINPATH] = "#{orfeo.opt_prefix}"
       begin
         inreplace "#{proc_plugins}/otb/OTBUtils.py" do |s|
         # default geoid path
         # try to replace first, so it fails (if already done) before global replaces
-        s.sub! "OTB_GEOID_FILE) or ''", "OTB_GEOID_FILE) or '#{orfeo6.opt_libexec}/default_geoid/egm96.grd'"
-        # default bin and lib path
-        s.gsub! "/usr/local/bin", orfeo6.opt_bin.to_s
-        s.gsub! "/usr/local/lib", orfeo6.opt_lib.to_s
+        s.sub! "OTB_FOLDER", "#{orfeo.opt_prefix}"
+        s.sub! "OTB_APP_FOLDER", "#{orfeo.opt_lib}/otb/applications"
+        s.sub! "OTB_GEOID_FILE", "#{orfeo.opt_libexec}/default_geoid/egm96.grd"
         end
         puts "ORFEO 6 OTBUtils.py has been updated"
         rescue Utils::InreplaceError
@@ -859,12 +936,50 @@ class Qgis < Formula
         end
         puts "R RAlgorithmProvider.py has been updated"
         rescue Utils::InreplaceError
-        puts "R RAlgorithmProvider.py already updated"
+        puts "R provider.py already updated"
+      end
+    end
+
+    if opts.include?("with-whitebox") || brewed_whitebox?
+      begin
+        whitebox="#{Formula["whitebox-tools"].opt_bin}/whitebox_tools"
+        inreplace "#{proc_plugins}/processing_whitebox/whiteboxProvider.py" do |s|
+        s.gsub! "/usr/local/opt/whitebox-tools/bin/whitebox_tools", "#{whitebox}"
+        end
+        puts "Whitebox Tools whiteboxProvider.py has been updated"
+        rescue Utils::InreplaceError
+        puts "Whitebox Tools whiteboxProvider.py already updated"
+      end
+    end
+
+    if opts.include?("with-taudem") || brewed_taudem?
+      begin
+        taudem="#{Formula["taudem"].opt_bin}"
+        mpich="#{Formula["open-mpi"].opt_bin}"
+        inreplace "#{proc_plugins}/processing_taudem/taudemProvider.py" do |s|
+        s.gsub! "/usr/local/opt/taudem/bin", "#{taudem}"
+        s.gsub! "/usr/local/opt/open-mpi/bin", "#{mpich}"
+        end
+        puts "TauDEM taudemProvider.py and has been updated"
+        rescue Utils::InreplaceError
+        puts "TauDEM taudemProvider.py already updated"
+      end
+    end
+
+    if opts.include?("with-lastools") || brewed_lastools?
+      begin
+        lastools="#{Formula["lastools"].opt_prefix}"
+        inreplace "#{proc_plugins}/lastools/LAStoolsProvider.py" do |s|
+        s.gsub! 'C:\LAStools', "#{lastools}"
+        end
+        puts "LAStools LAStoolsProvider.py has been updated"
+        rescue Utils::InreplaceError
+        puts "LAStools LAStoolsProvider.py already updated"
       end
     end
 
     unless opts.include?("without-globe")
-      osg = Formula["open-scene-graph"]
+      osg = Formula["openscenegraph-qt5"]
       envars[:OSG_LIBRARY_PATH] = "#{HOMEBREW_PREFIX}/lib/osgPlugins-#{osg.version}"
     end
 
@@ -929,65 +1044,91 @@ class Qgis < Formula
 
   def caveats
     s = <<~EOS
-      Bottles support only Homebrew's Python3
+      \nQGIS is built as an application bundle. Environment variables for the
+      Homebrew prefix are embedded in \e[32mQGIS.app\e[0m:
 
-      QGIS is built as an application bundle. Environment variables for the
-      Homebrew prefix are embedded in QGIS.app:
-        #{opt_prefix}/QGIS.app
+        \e[32m#{opt_prefix}/QGIS.app\e[0m
 
-      You may also symlink QGIS.app into /Applications or ~/Applications:
-        ln -Fs `find $(brew --prefix) -name "QGIS.app"` /Applications/QGIS.app
+      You may also symlink \e[32mQGIS.app\e[0m into \e[32m/Applications\e[0m or \e[32m~/Applications\e[0m:
 
-      To directly run the `QGIS.app/Contents/MacOS/QGIS` binary use the wrapper
+        \e[32mln -Fs `find $(brew --prefix) -name "QGIS.app"` /Applications/QGIS.app\e[0m
+
+      To directly run the \e[32m`QGIS.app/Contents/MacOS/QGIS`\e[0m binary use the wrapper
       script pre-defined with Homebrew prefix environment variables:
-        #{opt_bin}/#{name}
+
+        \e[32m#{opt_bin}/#{name}\e[0m
+
+      If you need QGIS to appear in Spotlight, create and run the following script:
+
+        \e[32m#!/usr/bin/env bash\e[0m
+
+        \e[32mqgis_location=$(find $(brew --prefix)/Cellar/qgis/ -name "3.*" -print -quit)/QGIS.app\e[0m
+        \e[32mosascript -e 'tell application "Finder"' -e 'make new alias to file (posix file "'$qgis_location'") at (posix file "/Applications")' -e 'end tell'\e[0m
+
+
+        https://github.com/OSGeo/homebrew-osgeo4mac/issues/607#issuecomment-455905926
 
       NOTE: Your current PATH and PYTHONPATH environment variables are honored
-            when launching via the wrapper script, while launching QGIS.app
+            when launching via the wrapper script, while launching \e[32mQGIS.app\e[0m
             bundle they are not.
 
-      For standalone Python3 development, set the following environment variable:
-        export PYTHONPATH=#{qgis_python_packages}:#{gdal_python_packages}:#{python_site_packages}:$PYTHONPATH
+      For standalone Python 3 development, set the following environment variable:
+
+        \e[32mexport PYTHONPATH=#{python_site_packages}:#{qgis_site_packages}:#{qgis_python_packages}:#{gdal_python_packages}:$PYTHONPATH\e[0m
 
     EOS
 
     if build.with? "isolation"
       s += <<~EOS
-        QGIS built with isolation enabled. This allows it to coexist with other
+        \033[31mQGIS built with isolation enabled. This allows it to coexist with other
         types of installations of QGIS on your Mac. However, on versions >= 2.0.1,
         this also means Python modules installed in the *system* Python will NOT
-        be available to Python processes within QGIS.app.
+        be available to Python processes within QGIS.app.\e[0m
 
       EOS
     end
 
-    if build.with?("orfeo") || ("r")
+    s += <<~EOS
+      QGIS plugins may need extra Python modules to function. Most can be installed
+      with \e[32mpip\e[0m in a Terminal:
+
+          \e[32mpip3 install modulename\e[0m
+
+      If you want to upgrade modules, add the \e[32m-U\e[0m option:
+
+          \e[32mpip3 install -U modulename\e[0m
+
+    EOS
+
+    s += <<~EOS
+
+      Activate plugins
+
+        \e[32mManage and Install Plugins -> Installed ->  Plugin name\e[0m (click its checkbox)
+
+    EOS
+
+    if build.with? "lastools"
       s += <<~EOS
 
-        Activate plugin
-        Manage and Install Plugins -> Installed ->  Plugin name (click its checkbox)
+        You installed LASTools. If you will use wine to have more features,
+        you will need to manually enter the path where
+        you unzipped LASTools and Wine path (\e[32m#{Formula["wine"].opt_prefix}\e[0m).
 
       EOS
     end
 
+    if build.with? "grass"
+      s += <<~EOS
+        If you have built GRASS 7 for the Processing plugin set the following in QGIS
 
-    s += <<~EOS
-      QGIS plugins may need extra Python modules to function. Most can be installed with pip in a Terminal:
+          \e[32mProcessing -> Options: Providers -> GRASS GIS 7 commands -> GRASS 7 folder\e[0m
 
-          pip3 install modulename
+          to \e[32m#{HOMEBREW_PREFIX}/opt/grass7/grass-base\e[0m
 
-      If you want to upgrade modules, add the -U option:
-
-          pip3 install -U modulename
-
-    EOS
-
-    s += <<~EOS
-      If you have built GRASS 7 for the Processing plugin set the following in QGIS:
-        Processing->Options: Providers->GRASS GIS 7 commands->GRASS 7 folder to:
-           #{HOMEBREW_PREFIX}/opt/grass7/grass-base
-    EOS
-    s
+      EOS
+      s
+    end
   end
 
   test do
@@ -997,16 +1138,64 @@ class Qgis < Formula
 
   private
 
-  def brewed_grass7?
+  def brewed_grass?
     Formula["grass7"].opt_prefix.exist?
   end
 
-  def brewed_orfeo6?
+  def brewed_saga?
+    Formula["saga-gis-lts"].opt_prefix.exist?
+  end
+
+  def brewed_orfeo?
     Formula["orfeo6"].opt_prefix.exist?
   end
 
+  def brewed_gpsbabel?
+    Formula["gpsbabel"].opt_prefix.exist?
+  end
+
+  # def brewed_openscenegraph?
+  #   Formula["openscenegraph-qt5"].opt_prefix.exist?
+  # end
+
+  # def brewed_osgqt?
+  #   Formula["osgqt"].opt_prefix.exist?
+  # end
+
+  # def brewed_osgearth?
+  #   Formula["osgearth-qt5"].opt_prefix.exist?
+  # end
+
   def brewed_r?
     Formula["r"].opt_prefix.exist?
+  end
+
+  def brewed_lastools?
+    Formula["lastools"].opt_prefix.exist?
+  end
+
+  def brewed_taudem?
+    Formula["taudem"].opt_prefix.exist?
+  end
+
+  def brewed_whitebox?
+    Formula["whitebox-tools"].opt_prefix.exist?
+  end
+
+  def brewed_fcgi?
+    Formula["fcgi"].opt_prefix.exist?
+  end
+
+  # def brewed_postgresql?
+  #   Formula["postgresql"].opt_prefix.exist?
+  # end
+
+  # def brewed_postgresql10?
+  #   Formula["postgresql@10"].opt_prefix.exist?
+  # end
+
+  def brewed_oracle?
+    Formula["oracle-client-sdk"].opt_prefix.exist?
   end
 
   def brewed_python?
@@ -1015,7 +1204,7 @@ class Qgis < Formula
 
   def python_exec
     if brewed_python?
-      libexec/"vendor/bin/python3"
+      "#{Formula["python"].opt_bin}/python3"
     else
       py_exec = `which python3`.strip
       raise if py_exec == ""
@@ -1027,28 +1216,32 @@ class Qgis < Formula
     `#{python_exec} -c 'import sys;print("{0}.{1}".format(sys.version_info[0],sys.version_info[1]))'`.strip
   end
 
-  def python_site_packages
-    libexec/"vendor/lib/python#{py_ver}/site-packages"
-  end
-
   def python_prefix
     `#{python_exec} -c 'import sys;print(sys.prefix)'`.strip
   end
 
   def qgis_python_packages
-    opt_lib/"python#{py_ver}/site-packages".to_s
+    "#{opt_prefix}/QGIS.app/Contents/Resources/python"
+  end
+
+  def qgis_site_packages
+    "#{opt_lib}/python#{py_ver}/site-packages"
+  end
+
+  def python_site_packages
+    "#{HOMEBREW_PREFIX}/opt/lib/python#{py_ver}/site-packages"
   end
 
   def gdal_python_packages
-    Formula["gdal2-python"].opt_lib/"python#{py_ver}/site-packages".to_s
+    "#{Formula["gdal2-python"].opt_lib}/python#{py_ver}/site-packages"
   end
 
   def gdal_python_opt_bin
-    Formula["gdal2-python"].opt_bin.to_s
+    "#{Formula["gdal2-python"].opt_bin}"
   end
 
   def gdal_opt_bin
-    Formula["gdal2"].opt_bin.to_s
+    "#{Formula["gdal2"].opt_bin}"
   end
 
   def module_importable?(mod)
@@ -1095,3 +1288,23 @@ __END__
      if sys.platform.startswith('freebsd'):
          py_version = str(sys.version_info.major) + str(sys.version_info.minor)
          sip_dir = sip_dir.replace(py_version, '')
+
+--- a/src/ui/qgsabout.ui
++++ b/src/ui/qgsabout.ui
+@@ -244,6 +244,16 @@
+               </size>
+              </property>
+             </spacer>
++           </item>
++           <item>
++            <widget class="QLabel" name="label_osgeo">
++             <property name="text">
++              <string>OSGeo4Mac Team / Maintainer: @fjperini - Collaborators: @nickrobison and @lpuerto</string>
++             </property>
++             <property name="alignment">
++              <set>Qt::AlignCenter</set>
++             </property>
++            </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_3">


### PR DESCRIPTION
 Is used `qgis-res` to have more Python Modules and save build time after installing this dependency. Also to solve reported problems by not finding some of the required modules.