### PR TITLE
Downgrade to GDAL 2 and proj 5.2

### DIFF
--- a/Formula/osgeo-gdal-python.rb
+++ b/Formula/osgeo-gdal-python.rb
@@ -31,20 +31,19 @@ class OsgeoGdalPython < Formula
 
   desc "Python bindings for GDAL: Geospatial Data Abstraction Library"
   homepage "https://pypi.python.org/pypi/GDAL"
-  url "https://github.com/OSGeo/gdal/releases/download/v3.0.1/gdal-3.0.1.tar.gz"
-  sha256 "37fd5b61fabc12b4f13a556082c680025023f567459f7a02590600344078511c"
+  url "https://download.osgeo.org/gdal/2.4.1/gdal-2.4.1.tar.gz"
+  sha256 "f1a11d1982205b9e4cc10e16f016a5559bfc9fa9a9ea69015e99ccd6a738ea4c"
 
-  # revision 1
+  revision 1
 
   head "https://github.com/OSGeo/gdal.git", :branch => "master"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
     cellar :any
-    rebuild 1
-    sha256 "9d9c504525f08286020cbf4e99619136552349707cb822235c5c926e5ff22755" => :mojave
-    sha256 "9d9c504525f08286020cbf4e99619136552349707cb822235c5c926e5ff22755" => :high_sierra
-    sha256 "4267860e13ab436cddb485b35c23225278e762603ca0f9ffe3858789ee5359cc" => :sierra
+    sha256 "53defb86be93bbeb180c9e8c32098dacc963c2093871baccdd151923209e15e3" => :mojave
+    sha256 "53defb86be93bbeb180c9e8c32098dacc963c2093871baccdd151923209e15e3" => :high_sierra
+    sha256 "df1689e7985c7d9dad55f888a54e3b3b63775ca5a698c0f681a57adc7026655d" => :sierra
   end
 
   keg_only "older version of gdal is in main tap and installs similar components"
@@ -56,8 +55,8 @@ class OsgeoGdalPython < Formula
   depends_on "osgeo-gdal"
 
   resource "autotest" do
-    url "https://download.osgeo.org/gdal/3.0.1/gdalautotest-3.0.1.tar.gz"
-    sha256 "36551c612509549a10d23012c46a81da61213dc617835e773f105b5682c95b5c"
+    url "https://download.osgeo.org/gdal/2.4.1/gdalautotest-2.4.1.tar.gz"
+    sha256 "ce70807792f35f66f0f3dfa0e2d41071bf845d9b65cebd97279620cf90a30603"
   end
 
   def install

--- a/Formula/osgeo-gdal.rb
+++ b/Formula/osgeo-gdal.rb
@@ -20,8 +20,8 @@ end
 class OsgeoGdal < Formula
   desc "GDAL: Geospatial Data Abstraction Library"
   homepage "https://www.gdal.org/"
-  url "https://github.com/OSGeo/gdal/releases/download/v3.0.1/gdal-3.0.1.tar.gz"
-  sha256 "37fd5b61fabc12b4f13a556082c680025023f567459f7a02590600344078511c"
+  url "https://github.com/OSGeo/gdal/archive/v2.4.1.tar.gz"
+  sha256 "17f94c0dfbecab2fc2433428766860de3c89c3fba57f5c9aa77749c1824c02aa"
 
   # revision 1
 
@@ -33,9 +33,9 @@ class OsgeoGdal < Formula
   bottle do
     root_url "https://bottle.download.osgeo.org"
     rebuild 1
-    sha256 "d0cbdae3e3a2358c2cdb25e15342761ddb2443d190c1b55122aca9de3049a2f2" => :mojave
-    sha256 "d0cbdae3e3a2358c2cdb25e15342761ddb2443d190c1b55122aca9de3049a2f2" => :high_sierra
-    sha256 "7a3054267e2b5a26892d02fbed0fa1865a404987d7d660183a6b46193272a2a6" => :sierra
+    sha256 "328b641c25849e62af4c5ea4dbbe220dc30e690a058a3565979b517e1b2d8eb6" => :mojave
+    sha256 "328b641c25849e62af4c5ea4dbbe220dc30e690a058a3565979b517e1b2d8eb6" => :high_sierra
+    sha256 "89118915b410857aa34029d39979e4fc16354e425b2bb299961e2184d7b67ed1" => :sierra
   end
 
   # keg_only "gdal is already provided by homebrew/core"

--- a/Formula/osgeo-libgeotiff.rb
+++ b/Formula/osgeo-libgeotiff.rb
@@ -20,16 +20,15 @@ end
 class OsgeoLibgeotiff < Formula
   desc "Library and tools for dealing with GeoTIFF"
   homepage "https://geotiff.osgeo.org/"
-  url "https://github.com/OSGeo/libgeotiff/releases/download/1.5.1/libgeotiff-1.5.1.tar.gz"
-  sha256 "f9e99733c170d11052f562bcd2c7cb4de53ed405f7acdde4f16195cd3ead612c"
+  url "https://github.com/OSGeo/libgeotiff/archive/1.4.3.tar.gz"
+  sha256 "96fb426877a99ecb66a73c0b912f42995bc1275c1ae687bbaab9ad97c4e8bdf2"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
     cellar :any
-    rebuild 2
-    sha256 "aa85c9ce4cf3066e711fffef60d9b0d4b7d695f23db2bd0b3a944f9d13fc302e" => :mojave
-    sha256 "aa85c9ce4cf3066e711fffef60d9b0d4b7d695f23db2bd0b3a944f9d13fc302e" => :high_sierra
-    sha256 "0df43a0519ffdb05ca3418b4b1c43969979c557fed49fbcd4860003e63a2b8e6" => :sierra
+    sha256 "57618e1dc8caf1f9fd64faa7addef9f529db23beff2b9b0a2a42da0add7dd949" => :mojave
+    sha256 "57618e1dc8caf1f9fd64faa7addef9f529db23beff2b9b0a2a42da0add7dd949" => :high_sierra
+    sha256 "123fd4d0da7f1e4c6bf506229878c772219bc39f827dbed9e7ba9200890cdaa8" => :sierra
   end
 
   # revision 1
@@ -49,14 +48,14 @@ class OsgeoLibgeotiff < Formula
   depends_on "osgeo-proj"
 
   def install
-    # cd "libgeotiff" do
-      # system "./autogen.sh"
+     cd "libgeotiff" do
+      system "./autogen.sh"
       system "./configure", "--disable-dependency-tracking",
                             "--prefix=#{prefix}",
                             "--with-jpeg", "--with-zlib"
       system "make" # Separate steps or install fails
       system "make", "install"
-    # end
+    end
   end
 
   test do

--- a/Formula/osgeo-libspatialite.rb
+++ b/Formula/osgeo-libspatialite.rb
@@ -21,7 +21,7 @@ class OsgeoLibspatialite < Formula
   desc "Adds spatial SQL capabilities to SQLite"
   homepage "https://www.gaia-gis.it/fossil/libspatialite/index"
 
-  revision 3
+  revision 2
 
   stable do
     url "https://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz"
@@ -37,10 +37,9 @@ class OsgeoLibspatialite < Formula
   bottle do
     root_url "https://bottle.download.osgeo.org"
     cellar :any
-    rebuild 1
-    sha256 "a2e339c3db3e6d777242159ae083a8abe27943c935c80c23a569772b5569364a" => :mojave
-    sha256 "a2e339c3db3e6d777242159ae083a8abe27943c935c80c23a569772b5569364a" => :high_sierra
-    sha256 "38b49ea931e017046f7014274d23d44f344779bee6049f539d32c69e670c7de3" => :sierra
+    sha256 "60c373eacb0e0786d860495678f3be8bf993008ecdac878e10be042446af1647" => :mojave
+    sha256 "60c373eacb0e0786d860495678f3be8bf993008ecdac878e10be042446af1647" => :high_sierra
+    sha256 "92ab0f182815f349661841dc412700d95bb01cb6104334c892810c4acc27158b" => :sierra
   end
 
 

--- a/Formula/osgeo-proj.rb
+++ b/Formula/osgeo-proj.rb
@@ -19,21 +19,21 @@ end
 
 class OsgeoProj < Formula
   desc "Cartographic Projections Library"
-  homepage "https://proj.org/"
-  url "https://github.com/OSGeo/PROJ/releases/download/6.2.0/proj-6.2.0.tar.gz"
-  sha256 "b300c0f872f632ad7f8eb60725edbf14f0f8f52db740a3ab23e7b94f1cd22a50"
+  homepage "https://proj4.org/"
+  url "https://github.com/OSGeo/proj.4/archive/5.2.0.tar.gz"
+  sha256 "d784d51a8e56282123eb5918a2c685ed7da5097595afcacf5fa0246337a44361"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
     rebuild 1
-    sha256 "ab073d23b26a4fc7e08753f9b521ef82d3daebf3dc71ac17bb57d732f1365e6c" => :mojave
-    sha256 "ab073d23b26a4fc7e08753f9b521ef82d3daebf3dc71ac17bb57d732f1365e6c" => :high_sierra
-    sha256 "67ee4e6f85907d9efa2c2f6bce2790391c07167e0a3dbf9def24bb1767695d17" => :sierra
+    sha256 "4b35b6321e2b91c0e5662952990735991d3c7178d90bf3e79b5278568fcad883" => :mojave
+    sha256 "4b35b6321e2b91c0e5662952990735991d3c7178d90bf3e79b5278568fcad883" => :high_sierra
+    sha256 "815974df0698547ad5c264f3be4cd5f03dadcc88e5e613eea9cbbcbf01d5f069" => :sierra
   end
 
   # revision 1
 
-  head "https://github.com/OSGeo/PROJ.git", :branch => "master"
+  head "https://github.com/OSGeo/proj.4.git", :branch => "master"
 
   # keg_only "proj" is already provided by homebrew/core"
   # we will verify that other versions are not linked
@@ -57,7 +57,7 @@ class OsgeoProj < Formula
   def install
     (buildpath/"nad").install resource("datumgrid")
 
-    # system "./autogen.sh"
+    system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
It also includes gdal-python, libgeotiff and libspatialite

# Description

Core formulas from the repository have been recently upgraded and bumped to new major versions: GDAL (2.4.1 > 3.0.1) and Proj (5.2.0 > 6.2.0).

These changes haven't been rolled to all related formula yet, and consequently tap is broken.
This is a proposal to downgrade this formulas to its previous state while these changes are tested and fully applied. The code has been copied from previous commits, so there is nothing new. As bottles are already created, there is no need to bottle them again. When needed, these downgrade will be easily undone.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Hardware:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules