### PR TITLE
Resolve #1277 Fix Issue Template URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,8 +11,8 @@ assignees: ''
 
 I've... 
 - I read
-	- [ ] the [reporting issues](https://github.com/OSGeo/homebrew-osgeo4mac/docs/reporting-issues)
-	- [ ] the [troubleshooting](https://github.com/OSGeo/homebrew-osgeo4mac/docs/troubleshooting)
+	- [ ] the [reporting issues](https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/docs/docs/reporting-issues.md)
+	- [ ] the [troubleshooting](https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/docs/docs/troubleshooting.md)
 - [ ] I checked the documentation and found no answer
 - [ ] I tried to install after following the suggestions
 - [ ] I am running the latest version (`brew update` twice?)


### PR DESCRIPTION
# Description

In order to help future contributors this update corrects the location of the GitHub Issue template URLs.

Fixes #1277

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I clicked the links.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules