### PR TITLE
fix java dependencies

### DIFF
--- a/Formula/mapserver6.rb
+++ b/Formula/mapserver6.rb
@@ -60,7 +60,7 @@ class Mapserver6 < Formula
   depends_on "libpng"
   depends_on "python@2"
   depends_on "swig" => :build
-  depends_on :java => :optional
+  depends_on "openjdk" => :optional
   depends_on "giflib"
   depends_on "osgeo-proj"
   depends_on "geos" => :recommended

--- a/Formula/osgeo-gmt.rb
+++ b/Formula/osgeo-gmt.rb
@@ -36,7 +36,7 @@ class OsgeoGmt < Formula
   # depends_on "texlive"
 
   # Using CFLAGS = -I/Library/Java/JavaVirtualMachines/..
-  depends_on :java => ["1.8", :build]
+  depends_on "openjdk" => :build
 
   # OpenMP support: disabled
 

--- a/Formula/osgeo-insighttoolkit.rb
+++ b/Formula/osgeo-insighttoolkit.rb
@@ -37,7 +37,7 @@ class OsgeoInsighttoolkit < Formula
   depends_on "osgeo-vtk" => :build
 
   # JAVA_VERSION = "1.8" # "1.10+"
-  depends_on :java => ["1.8", :build] # JAVA_VERSION
+  depends_on "openjdk" => :build # JAVA_VERSION
 
   depends_on "zlib"
   depends_on "bison"

--- a/Formula/osgeo-insighttoolkit@4.rb
+++ b/Formula/osgeo-insighttoolkit@4.rb
@@ -39,7 +39,7 @@ class OsgeoInsighttoolkitAT4 < Formula
   depends_on "osgeo-vtk" => :build
 
   # JAVA_VERSION = "1.8" # "1.10+"
-  depends_on :java => ["1.8", :build] # JAVA_VERSION
+  depends_on "openjdk" => :build # JAVA_VERSION
 
   depends_on "zlib"
   depends_on "bison"

--- a/Formula/osgeo-ossim.rb
+++ b/Formula/osgeo-ossim.rb
@@ -63,7 +63,7 @@ class OsgeoOssim < Formula
   # Geotrans
   # MrSid
 
-  depends_on :java => :optional # => ["1.8", :build]
+  depends_on "openjdk" => :optional # => ["1.8", :build]
 
   if build.with? "pg10"
     depends_on "osgeo-postgresql@10"

--- a/Formula/osgeo-pcl.rb
+++ b/Formula/osgeo-pcl.rb
@@ -42,7 +42,7 @@ class OsgeoPcl < Formula
   depends_on "osgeo-vtk"
   depends_on "osgeo-qt-webkit"
 
-  depends_on :java => ["1.8", :build]
+  depends_on "openjdk" => :build
 
   # openni2
   # cuda

--- a/Formula/osgeo-vtk.rb
+++ b/Formula/osgeo-vtk.rb
@@ -145,7 +145,7 @@ class OsgeoVtk < Formula
   depends_on "osgeo-matplotlib"
 
   # JAVA_VERSION = "1.8" # "1.10+"
-  depends_on :java => ["1.8", :build] # JAVA_VERSION
+  depends_on "openjdk" => :build # JAVA_VERSION
 
   depends_on "gl2ps"
   depends_on "libharu"

--- a/Formula/osgeo-whitebox.rb
+++ b/Formula/osgeo-whitebox.rb
@@ -18,7 +18,7 @@ class OsgeoWhitebox < Formula
   option "with-app", "Build WBT.app Package"
 
   depends_on "bash"
-  # depends_on :java
+  # depends_on "openjdk"
 
   def install
 


### PR DESCRIPTION
# Description

As of Brew 2.6, the `depends_on` syntax that was used for `java` is no longer supported. This PR addresses this.

Fixes #1407 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested installing this from my own fork/tap on Big Sur, Homebrew 2.7.5-56-g33dafa4, 2,6 GHz 6-Core Intel Core i7.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules