### PR TITLE
Auto-fix code style

### DIFF
--- a/Formula/osgeo-gdal-python.rb
+++ b/Formula/osgeo-gdal-python.rb
@@ -30,24 +30,23 @@ class OsgeoGdalPython < Formula
   url "https://download.osgeo.org/gdal/3.1.2/gdal-3.1.2.tar.xz"
   sha256 "767c8d0dfa20ba3283de05d23a1d1c03a7e805d0ce2936beaff0bb7d11450641"
 
-  #revision 2 
+  # revision 2
 
-  head "https://github.com/OSGeo/gdal.git", :branch => "master"
+  head "https://github.com/OSGeo/gdal.git", branch: "master"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    cellar :any
-    sha256 "8e2ddaec0874f61df018c622cbf465985ae4dde2171d280464d15d02c72af192" => :catalina
-    sha256 "8e2ddaec0874f61df018c622cbf465985ae4dde2171d280464d15d02c72af192" => :mojave
-    sha256 "8e2ddaec0874f61df018c622cbf465985ae4dde2171d280464d15d02c72af192" => :high_sierra
+    sha256 cellar: :any, catalina:    "8e2ddaec0874f61df018c622cbf465985ae4dde2171d280464d15d02c72af192"
+    sha256 cellar: :any, mojave:      "8e2ddaec0874f61df018c622cbf465985ae4dde2171d280464d15d02c72af192"
+    sha256 cellar: :any, high_sierra: "8e2ddaec0874f61df018c622cbf465985ae4dde2171d280464d15d02c72af192"
   end
 
   keg_only "older version of gdal is in main tap and installs similar components"
 
   depends_on "swig" => :build
-  depends_on "python" => :recommended
   depends_on "numpy"
   depends_on "osgeo-gdal"
+  depends_on "python" => :recommended
 
   resource "autotest" do
     url "https://download.osgeo.org/gdal/3.1.2/gdalautotest-3.1.2.tar.gz"
@@ -55,7 +54,6 @@ class OsgeoGdalPython < Formula
   end
 
   def install
-
     cd "swig/python" do
       # Customize to gdal install opt_prefix
       inreplace "setup.cfg" do |s|
@@ -82,12 +80,13 @@ class OsgeoGdalPython < Formula
     end
   end
 
-  def caveats; <<~EOS
-    Sample Python scripts installed to:
-      #{opt_libexec}/bin
+  def caveats
+    <<~EOS
+      Sample Python scripts installed to:
+        #{opt_libexec}/bin
 
-    To run full test suite use:
-      `brew test -v #{name} --with-autotest`
+      To run full test suite use:
+        `brew test -v #{name} --with-autotest`
     EOS
   end
 
@@ -95,6 +94,7 @@ class OsgeoGdalPython < Formula
     python_version = Language::Python.major_minor_version "python3"
 
     next unless (lib/"python#{python_version}/site-packages").exist?
+
     ENV["PYTHONPATH"] = lib/"python#{python_version}/site-packages"
     pkgs = %w[gdal ogr osr gdal_array gdalconst]
     pkgs << "gnm" unless gdal_opts.include? "without-gnm"
@@ -108,17 +108,15 @@ class OsgeoGdalPython < Formula
       # These driver tests cause hard failures, stopping test output
       ENV["GDAL_SKIP"] = "GRASS"
       ENV["OGR_SKIP"] = "ElasticSearch,GFT,OGR_GRASS"
-      Language::Python.each_python(build) do |python, python_version|
+      Language::Python.each_python(build) do |_python, python_version|
         ENV["PYTHONPATH"] = opt_lib/"python#{python_version}/site-packages"
         resource("autotest").stage do
           # Split up tests, to reduce chance of execution expiration
           # ogr gcore gdrivers osr alg gnm utilities pyscripts
           %w[ogr gcore gdrivers osr alg gnm utilities pyscripts].each do |t|
-            begin
-              system "python3", "run_all.py", t.to_s
-            rescue
-              next
-            end
+            system "python3", "run_all.py", t.to_s
+          rescue
+            next
           end
         end
         # Run autotest just once, with first found binding

--- a/Formula/osgeo-gdal.rb
+++ b/Formula/osgeo-gdal.rb
@@ -1,18 +1,20 @@
 class Unlinked < Requirement
   fatal true
 
-  satisfy(:build_env => false) { !core_gdal_linked }
+  satisfy(build_env: false) { !core_gdal_linked }
 
   def core_gdal_linked
     Formula["gdal"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def message
     s = "\033[31mYou have other linked versions!\e[0m\n\n"
 
-    s += "Unlink with \e[32mbrew unlink gdal\e[0m or remove with brew \e[32muninstall --ignore-dependencies gdal\e[0m\n\n" if core_gdal_linked
+    if core_gdal_linked
+      s += "Unlink with \e[32mbrew unlink gdal\e[0m or remove with brew \e[32muninstall --ignore-dependencies gdal\e[0m\n\n"
+    end
     s
   end
 end
@@ -22,89 +24,86 @@ class OsgeoGdal < Formula
   homepage "https://www.gdal.org/"
   url "https://download.osgeo.org/gdal/3.1.2/gdal-3.1.2.tar.xz"
   sha256 "767c8d0dfa20ba3283de05d23a1d1c03a7e805d0ce2936beaff0bb7d11450641"
-  #url "https://github.com/OSGeo/gdal.git",
+  # url "https://github.com/OSGeo/gdal.git",
   #  :branch => "release/3.1",
   #  :commit => "a9e385e76d8f4e7891d10adf1fc99fe3a4a89602"
-  #version "3.1.2"
+  # version "3.1.2"
 
-  revision 2  
-
-  head do
-    url "https://github.com/OSGeo/gdal.git", :branch => "master"
-    depends_on "doxygen" => :build
-  end
+  revision 2
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
     rebuild 1
-    sha256 "5c0cfe587fff624ed20d33db5ffbf2c7f9bc9af026a9bcecf795b1a07193925d" => :catalina
-    sha256 "5c0cfe587fff624ed20d33db5ffbf2c7f9bc9af026a9bcecf795b1a07193925d" => :mojave
-    sha256 "5c0cfe587fff624ed20d33db5ffbf2c7f9bc9af026a9bcecf795b1a07193925d" => :high_sierra
+    sha256 catalina:    "5c0cfe587fff624ed20d33db5ffbf2c7f9bc9af026a9bcecf795b1a07193925d"
+    sha256 mojave:      "5c0cfe587fff624ed20d33db5ffbf2c7f9bc9af026a9bcecf795b1a07193925d"
+    sha256 high_sierra: "5c0cfe587fff624ed20d33db5ffbf2c7f9bc9af026a9bcecf795b1a07193925d"
+  end
+
+  head do
+    url "https://github.com/OSGeo/gdal.git", branch: "master"
+    depends_on "doxygen" => :build
   end
 
   # keg_only "gdal is already provided by homebrew/core"
   # we will verify that other versions are not linked
-  depends_on Unlinked
-
   option "with-pg10", "Build with PostgreSQL 10 client"
   option "with-pg11", "Build with PostgreSQL 11 client"
-  #deprecated_option "with-postgresql10" => "with-pg10"
 
+  depends_on "openjdk" => :build
   depends_on "pkg-config" => :build
-  depends_on "armadillo"
   depends_on "ant"
-  #depends_on "cryptopp"
+  depends_on "armadillo"
+  depends_on "cfitsio"
   depends_on "curl-openssl"
+  depends_on "epsilon"
   depends_on "expat"
   depends_on "freexl"
   depends_on "geos"
   depends_on "giflib"
+  depends_on "hdf5"
+  depends_on "jasper"
+  depends_on "jpeg-turbo"
   depends_on "json-c"
+  depends_on "libdap"
+  depends_on "libiconv"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libxml2"
+  depends_on "libzip"
   depends_on "mdbtools"
   depends_on "numpy"
-  depends_on "libiconv"
-  depends_on "osgeo-libkml"
-  depends_on "libpq"
-  depends_on "osgeo-libspatialite"
-  depends_on "libzip"
-  depends_on "pcre" # for REGEXP operator in SQLite/Spatialite driver
+  depends_on "openjpeg"
   depends_on "openssl"
+  depends_on "osgeo-hdf4"
+  depends_on "osgeo-libkml"
+  depends_on "osgeo-libspatialite"
+  depends_on "osgeo-netcdf"
+  depends_on "osgeo-proj"
+  depends_on "pcre"
   depends_on "qhull"
   depends_on "sfcgal"
-  depends_on "sqlite" # To ensure compatibility with SpatiaLite.
+  depends_on "sqlite"
   depends_on "swig"
-  depends_on "zlib"
-  
-  depends_on "openjdk" => :build
-  
-  # Raster libraries
-  depends_on "cfitsio"
-  depends_on "epsilon"
-  depends_on "osgeo-hdf4"
-  depends_on "hdf5"
-  #depends_on "jpeg"
-  depends_on "jpeg-turbo"
-  depends_on "jasper"
-  depends_on "libdap"
-  #depends_on "osgeo-libgeotiff"
-  depends_on "libpng"
-  #depends_on "libtiff"
-  depends_on "libxml2"
-  depends_on "osgeo-netcdf" # Also brings in HDF5
-  depends_on "openjpeg"
+  depends_on "unixodbc"
+  depends_on Unlinked
+  # deprecated_option "with-postgresql10" => "with-pg10"
+  # depends_on "cryptopp" # for REGEXP operator in SQLite/Spatialite driver # To ensure compatibility with SpatiaLite.
   depends_on "webp"
+  depends_on "xerces-c"
+  depends_on "xz"
+  depends_on "zlib"
+
+  # Raster libraries
+  # depends_on "jpeg"
+  # depends_on "osgeo-libgeotiff"
+  # depends_on "libtiff" # Also brings in HDF5
   depends_on "zstd"
 
-  # Vector libraries
-  depends_on "unixodbc" # OS X version is not complete enough
-  depends_on "xerces-c"
+  # Vector libraries # OS X version is not complete enough
 
-  # Other libraries
-  depends_on "xz" # get liblzma compression algorithm library from XZutils
+  # Other libraries # get liblzma compression algorithm library from XZutils
 
   # depends_on "charls" # cask
-
-  depends_on "osgeo-proj"
 
   if build.with?("pg10")
     depends_on "osgeo-postgresql@10"
@@ -138,7 +137,7 @@ class OsgeoGdal < Formula
   #   See: https://github.com/rouault/pdfium
   # - Database support
 
-    # Fix build with Jasper.
+  # Fix build with Jasper.
   # Remove on next release.
   # https://github.com/OSGeo/gdal/issues/2844
   patch :p2 do
@@ -152,7 +151,7 @@ class OsgeoGdal < Formula
   end
 
   def configure_args
-    args = [
+    [
       "--prefix=#{prefix}",
       "--disable-debug",
       "--with-local=#{prefix}",
@@ -286,7 +285,6 @@ class OsgeoGdal < Formula
       # "--without-dwgdirect",
       # "--without-ruby",
     ]
-    args
   end
 
   def plugins_subdirectory
@@ -316,41 +314,41 @@ class OsgeoGdal < Formula
     ENV["ARCHFLAGS"] = "-arch #{Hardware::CPU.arch}"
 
     # chdir "gdal" do
-      # GDAL looks for the renamed hdf4 library, which is an artifact of old builds, so we need to repoint it
-      inreplace "configure", "-ldf", "-lhdf"
+    # GDAL looks for the renamed hdf4 library, which is an artifact of old builds, so we need to repoint it
+    inreplace "configure", "-ldf", "-lhdf"
 
-      # These libs are statically linked in libkml-dev and libkml formula
-      inreplace "configure", " -lminizip -luriparser", ""
+    # These libs are statically linked in libkml-dev and libkml formula
+    inreplace "configure", " -lminizip -luriparser", ""
 
-      # All PDF driver functionality moved to osgeo-gdal-pdf plugin,
-      # so nix default internal-built PDF w+ driver, which keeps plugin from loading.
-      # Just using --enable-pdf-plugin isn't enough (we don't want the plugin built here)
-      # inreplace "GDALmake.opt.in", "PDF_PLUGIN),yes", "PDF_PLUGIN),no"
-      # https://github.com/OSGeo/gdal/commit/20716436ce5debca66cbbe0396304e09b79bc3aa#diff-adc90aa0203327969e0048718b911252
+    # All PDF driver functionality moved to osgeo-gdal-pdf plugin,
+    # so nix default internal-built PDF w+ driver, which keeps plugin from loading.
+    # Just using --enable-pdf-plugin isn't enough (we don't want the plugin built here)
+    # inreplace "GDALmake.opt.in", "PDF_PLUGIN),yes", "PDF_PLUGIN),no"
+    # https://github.com/OSGeo/gdal/commit/20716436ce5debca66cbbe0396304e09b79bc3aa#diff-adc90aa0203327969e0048718b911252
 
-      args = configure_args
+    args = configure_args
 
-      system "./configure", *args
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Add GNM headers for osgeo-gdal-python swig wrapping
+    include.install Dir["gnm/**/*.h"]
+
+    cd "swig/java" do
+      inreplace "java.opt", "linux", "darwin"
+      inreplace "java.opt", "#JAVA_HOME = /usr/lib/jvm/java-6-openjdk/", "JAVA_HOME=#{ENV["JAVA_HOME"]}"
       system "make"
       system "make", "install"
 
-      # Add GNM headers for osgeo-gdal-python swig wrapping
-      include.install Dir["gnm/**/*.h"]
+      # Install the jar that complements the native JNI bindings
+      lib.install "gdal.jar"
+    end
 
-      cd "swig/java" do
-        inreplace "java.opt", "linux", "darwin"
-        inreplace "java.opt", "#JAVA_HOME = /usr/lib/jvm/java-6-openjdk/", "JAVA_HOME=#{ENV["JAVA_HOME"]}"
-        system "make"
-        system "make", "install"
-
-        # Install the jar that complements the native JNI bindings
-        lib.install "gdal.jar"
-      end
-
-      system "make", "man" if build.head?
-      system "make", "install-man"
-      # Clean up any stray doxygen files.
-      Dir.glob("#{bin}/*.dox") { |p| rm p }
+    system "make", "man" if build.head?
+    system "make", "install-man"
+    # Clean up any stray doxygen files.
+    Dir.glob("#{bin}/*.dox") { |p| rm p }
     # end
   end
 
@@ -360,7 +358,7 @@ class OsgeoGdal < Formula
   end
 
   def caveats
-    s = <<~EOS
+    <<~EOS
       Plugins for this version of GDAL/OGR, generated by other formulae, should
       be symlinked to the following directory:
 
@@ -372,7 +370,6 @@ class OsgeoGdal < Formula
 
       PYTHON BINDINGS are now built in a separate formula: osgeo-gdal-python
     EOS
-    s
   end
 
   test do

--- a/Formula/osgeo-hdf4.rb
+++ b/Formula/osgeo-hdf4.rb
@@ -3,23 +3,22 @@ class OsgeoHdf4 < Formula
   url "https://support.hdfgroup.org/ftp/HDF/releases/HDF4.2.14/src/hdf-4.2.14.tar.gz"
   sha256 "2d383e87c8a0ca6a5352adbd1d5546e6cc43dc21ff7d90f93efa644d85c0b14a"
 
+  bottle do
+    root_url "https://bottle.download.osgeo.org"
+    rebuild 1
+    sha256 cellar: :any, mojave:      "e9c44564bd0f3be8a6c7bb0d6f103fd64865a927a16f8ae5fc2b6a8a6e3221d7"
+    sha256 cellar: :any, high_sierra: "e9c44564bd0f3be8a6c7bb0d6f103fd64865a927a16f8ae5fc2b6a8a6e3221d7"
+    sha256 cellar: :any, sierra:      "a7d7759edd6ef51195fe94a77d20a76531c83f1460139acccad37791483ca135"
+  end
+
   option "with-fortran", "Build Fortran interface."
   option "with-tests", "Run the test suite (may fail)"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "szip" => :recommended
-  depends_on "jpeg"
   depends_on "gcc" if build.with? "fortran"
-
-  bottle do
-    root_url "https://bottle.download.osgeo.org"
-    cellar :any
-    rebuild 1
-    sha256 "e9c44564bd0f3be8a6c7bb0d6f103fd64865a927a16f8ae5fc2b6a8a6e3221d7" => :mojave
-    sha256 "e9c44564bd0f3be8a6c7bb0d6f103fd64865a927a16f8ae5fc2b6a8a6e3221d7" => :high_sierra
-    sha256 "a7d7759edd6ef51195fe94a77d20a76531c83f1460139acccad37791483ca135" => :sierra
-  end
+  depends_on "jpeg"
+  depends_on "szip" => :recommended
 
   resource "test_file" do
     url "https://gamma.hdfgroup.org/ftp/pub/outgoing/h4map/data/CT01_Rank6ArraysTablesAttributesGroups.hdf"
@@ -38,12 +37,12 @@ class OsgeoHdf4 < Formula
       "-DHDF4_BUILD_WITH_INSTALL_NAME=ON",
       "-DHDF4_ENABLE_JPEG_LIB_SUPPORT=ON",
       "-DHDF4_ENABLE_NETCDF=OFF", # Conflict. Just install NetCDF for this.
-      "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON"
+      "-DHDF4_ENABLE_Z_LIB_SUPPORT=ON",
     ]
 
     # szip has been reported to break linking with GDAL, so it may need to be disabled if you run into errors.
     if build.with? "szip"
-      args.concat %W[-DHDF4_ENABLE_SZIP_ENCODING=ON -DHDF4_ENABLE_SZIP_SUPPORT=ON]
+      args.concat %w[-DHDF4_ENABLE_SZIP_ENCODING=ON -DHDF4_ENABLE_SZIP_SUPPORT=ON]
     else
       args << "-DHDF4_ENABLE_SZIP_SUPPORT=OFF"
     end
@@ -64,11 +63,12 @@ class OsgeoHdf4 < Formula
       # Remove stray nc* artifacts which conflict with NetCDF.
       rm (bin+"ncdump")
       rm (bin+"ncgen")
-#      rm (include+"netcdf.inc")
+      #      rm (include+"netcdf.inc")
     end
   end
 
-  def caveats; <<~EOS
+  def caveats
+    <<~EOS
       HDF4 has been superseeded by HDF5.  However, the API changed
       substantially and some programs still require the HDF4 libraries in order
       to function.
@@ -80,5 +80,4 @@ class OsgeoHdf4 < Formula
       system "#{opt_prefix}/bin/vshow", "CT01_Rank6ArraysTablesAttributesGroups.hdf"
     end
   end
-
 end

--- a/Formula/osgeo-laszip@2.rb
+++ b/Formula/osgeo-laszip@2.rb
@@ -6,14 +6,13 @@ class OsgeoLaszipAT2 < Formula
 
   revision 1
 
-  head "https://github.com/LASzip/LASzip.git", :tag => "v2.2.0"
+  head "https://github.com/LASzip/LASzip.git", tag: "v2.2.0"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    cellar :any
-    sha256 "a785cd4b90dc00fb0454badb64aecab0ad033c7bae47e40afaa77fbd548c1f11" => :mojave
-    sha256 "a785cd4b90dc00fb0454badb64aecab0ad033c7bae47e40afaa77fbd548c1f11" => :high_sierra
-    sha256 "03096e03a39bd9605f8efc66d43299a794b5596ab58d56ca6b8a72b0498d6e8a" => :sierra
+    sha256 cellar: :any, mojave:      "a785cd4b90dc00fb0454badb64aecab0ad033c7bae47e40afaa77fbd548c1f11"
+    sha256 cellar: :any, high_sierra: "a785cd4b90dc00fb0454badb64aecab0ad033c7bae47e40afaa77fbd548c1f11"
+    sha256 cellar: :any, sierra:      "03096e03a39bd9605f8efc66d43299a794b5596ab58d56ca6b8a72b0498d6e8a"
   end
 
   keg_only :versioned_formula

--- a/Formula/osgeo-libgeotiff.rb
+++ b/Formula/osgeo-libgeotiff.rb
@@ -1,18 +1,20 @@
 class Unlinked < Requirement
   fatal true
 
-  satisfy(:build_env => false) { !core_libgeotiff_linked }
+  satisfy(build_env: false) { !core_libgeotiff_linked }
 
   def core_libgeotiff_linked
     Formula["libgeotiff"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def message
     s = "\033[31mYou have other linked versions!\e[0m\n\n"
 
-    s += "Unlink with \e[32mbrew unlink libgeotiff\e[0m or remove with brew \e[32muninstall --ignore-dependencies libgeotiff\e[0m\n\n" if core_libgeotiff_linked
+    if core_libgeotiff_linked
+      s += "Unlink with \e[32mbrew unlink libgeotiff\e[0m or remove with brew \e[32muninstall --ignore-dependencies libgeotiff\e[0m\n\n"
+    end
     s
   end
 end
@@ -23,35 +25,33 @@ class OsgeoLibgeotiff < Formula
   # url "https://github.com/OSGeo/libgeotiff/releases/download/1.6.0/libgeotiff-1.6.0.tar.gz"
   # sha256 "9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca"
   url "https://github.com/OSGeo/libgeotiff.git",
-    :branch => "master",
-    :commit => "8b1a8f52bc909f86e04ceadd699db102208074a2"
+    branch: "master",
+    commit: "8b1a8f52bc909f86e04ceadd699db102208074a2"
   version "1.6.0"
+
+  head "https://github.com/OSGeo/libgeotiff.git", branch: "master"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    cellar :any
-    sha256 "bcaf0e372b3a5c3875d695f34660d2efd90a728ade4960e1c7b4d9669bb29177" => :catalina
-    sha256 "bcaf0e372b3a5c3875d695f34660d2efd90a728ade4960e1c7b4d9669bb29177" => :mojave
-    sha256 "bcaf0e372b3a5c3875d695f34660d2efd90a728ade4960e1c7b4d9669bb29177" => :high_sierra
+    sha256 cellar: :any, catalina:    "bcaf0e372b3a5c3875d695f34660d2efd90a728ade4960e1c7b4d9669bb29177"
+    sha256 cellar: :any, mojave:      "bcaf0e372b3a5c3875d695f34660d2efd90a728ade4960e1c7b4d9669bb29177"
+    sha256 cellar: :any, high_sierra: "bcaf0e372b3a5c3875d695f34660d2efd90a728ade4960e1c7b4d9669bb29177"
   end
 
-  #revision 3 
-
-  head "https://github.com/OSGeo/libgeotiff.git", :branch => "master"
+  # revision 3
 
   # keg_only "libgeotiff is already provided by homebrew/core"
   # we will verify that other versions are not linked
-  depends_on Unlinked
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "gettext" => :build
+  depends_on "libtool" => :build
   depends_on "pkgconfig" => :build
   depends_on "jpeg"
-  depends_on "zlib"
   depends_on "libtiff"
   depends_on "osgeo-proj"
+  depends_on Unlinked
+  depends_on "zlib"
 
   def install
     cd "libgeotiff" do
@@ -98,6 +98,6 @@ class OsgeoLibgeotiff < Formula
                    "-L#{Formula["libtiff"].opt_lib}", "-ltiff", "-o", "test"
     system "./test", "test.tif"
     output = shell_output("#{bin}/listgeo test.tif")
-    assert_match /GeogInvFlatteningGeoKey.*123.456/, output
+    assert_match(/GeogInvFlatteningGeoKey.*123.456/, output)
   end
 end

--- a/Formula/osgeo-libkml.rb
+++ b/Formula/osgeo-libkml.rb
@@ -2,19 +2,18 @@ class OsgeoLibkml < Formula
   desc "Library to parse, generate and operate on KML (development version)"
   homepage "https://code.google.com/archive/p/libkml/"
   url "https://github.com/google/libkml/archive/8609edf7c8d13ae2ddb6eac2bca7c8e49c67a5f8.tar.gz"
-  sha256 "667cd86b7e66e38c71c054526e49c6ee9558b506c9ddec9e6de14b87e18c0072"
   version "1.3"
+  sha256 "667cd86b7e66e38c71c054526e49c6ee9558b506c9ddec9e6de14b87e18c0072"
 
   revision 1
 
-  head "https://github.com/google/libkml.git", :branch => "master"
+  head "https://github.com/google/libkml.git", branch: "master"
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    cellar :any
-    sha256 "3fabac80a848cec660adbba3aa0c9965bd03eb3e70e23e464b6706f897b5ccfb" => :mojave
-    sha256 "3fabac80a848cec660adbba3aa0c9965bd03eb3e70e23e464b6706f897b5ccfb" => :high_sierra
-    sha256 "d142c373ff382e20f8113a3490a595a4b5732d809ad06a95e46539766df3fdc5" => :sierra
+    sha256 cellar: :any, mojave:      "3fabac80a848cec660adbba3aa0c9965bd03eb3e70e23e464b6706f897b5ccfb"
+    sha256 cellar: :any, high_sierra: "3fabac80a848cec660adbba3aa0c9965bd03eb3e70e23e464b6706f897b5ccfb"
+    sha256 cellar: :any, sierra:      "d142c373ff382e20f8113a3490a595a4b5732d809ad06a95e46539766df3fdc5"
   end
 
   keg_only "older version is in main tap and installs similar components"
@@ -27,11 +26,11 @@ class OsgeoLibkml < Formula
     # See main `libkml` formula for info on patches
     inreplace "configure.ac", "-Werror", ""
     inreplace "third_party/Makefile.am" do |s|
-      s.sub! /(lib_LTLIBRARIES =) libminizip.la liburiparser.la/, "\\1"
-      s.sub! /(noinst_LTLIBRARIES = libgtest.la libgtest_main.la)/,
-             "\\1 libminizip.la liburiparser.la"
-      s.sub! /(libminizip_la_LDFLAGS =)/, "\\1 -static"
-      s.sub! /(liburiparser_la_LDFLAGS =)/, "\\1 -static"
+      s.sub!(/(lib_LTLIBRARIES =) libminizip.la liburiparser.la/, "\\1")
+      s.sub!(/(noinst_LTLIBRARIES = libgtest.la libgtest_main.la)/,
+             "\\1 libminizip.la liburiparser.la")
+      s.sub!(/(libminizip_la_LDFLAGS =)/, "\\1 -static")
+      s.sub!(/(liburiparser_la_LDFLAGS =)/, "\\1 -static")
     end
 
     system "./autogen.sh"

--- a/Formula/osgeo-libspatialite.rb
+++ b/Formula/osgeo-libspatialite.rb
@@ -1,18 +1,20 @@
 class Unlinked < Requirement
   fatal true
 
-  satisfy(:build_env => false) { !core_libspatialite_linked }
+  satisfy(build_env: false) { !core_libspatialite_linked }
 
   def core_libspatialite_linked
     Formula["libspatialite"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def message
     s = "\033[31mYou have other linked versions!\e[0m\n\n"
 
-    s += "Unlink with \e[32mbrew unlink libspatialite\e[0m or remove with brew \e[32muninstall --ignore-dependencies libspatialite\e[0m\n\n" if core_libspatialite_linked
+    if core_libspatialite_linked
+      s += "Unlink with \e[32mbrew unlink libspatialite\e[0m or remove with brew \e[32muninstall --ignore-dependencies libspatialite\e[0m\n\n"
+    end
     s
   end
 end
@@ -36,15 +38,13 @@ class OsgeoLibspatialite < Formula
   end
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    cellar :any
-    sha256 "bdf1b153bb5387bcf429f55a83758855da42b7e8f1e5488c7af19aece19ef5eb" => :catalina
-    sha256 "bdf1b153bb5387bcf429f55a83758855da42b7e8f1e5488c7af19aece19ef5eb" => :mojave
-    sha256 "bdf1b153bb5387bcf429f55a83758855da42b7e8f1e5488c7af19aece19ef5eb" => :high_sierra
+    sha256 cellar: :any, catalina:    "bdf1b153bb5387bcf429f55a83758855da42b7e8f1e5488c7af19aece19ef5eb"
+    sha256 cellar: :any, mojave:      "bdf1b153bb5387bcf429f55a83758855da42b7e8f1e5488c7af19aece19ef5eb"
+    sha256 cellar: :any, high_sierra: "bdf1b153bb5387bcf429f55a83758855da42b7e8f1e5488c7af19aece19ef5eb"
   end
 
-
   head do
-    url "https://www.gaia-gis.it/fossil/libspatialite", :using => :fossil
+    url "https://www.gaia-gis.it/fossil/libspatialite", using: :fossil
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
@@ -52,17 +52,16 @@ class OsgeoLibspatialite < Formula
 
   # keg_only "libspatialite" is already provided by homebrew/core"
   # we will verify that other versions are not linked
-  depends_on Unlinked
-
   depends_on "pkg-config" => :build
   depends_on "freexl"
   depends_on "geos"
   depends_on "libxml2"
   depends_on "osgeo-proj"
+  depends_on "sqlite"
+  depends_on Unlinked
   # Needs SQLite > 3.7.3 which rules out system SQLite on Snow Leopard and
   # below. Also needs dynamic extension support which rules out system SQLite
   # on Lion. Finally, RTree index support is required as well.
-  depends_on "sqlite"
 
   def install
     system "autoreconf", "-fi" if build.head?

--- a/Formula/osgeo-netcdf.rb
+++ b/Formula/osgeo-netcdf.rb
@@ -1,18 +1,20 @@
 class Unlinked < Requirement
   fatal true
 
-  satisfy(:build_env => false) { !core_netcdf_linked }
+  satisfy(build_env: false) { !core_netcdf_linked }
 
   def core_netcdf_linked
     Formula["netcdf"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def message
     s = "\033[31mYou have other linked versions!\e[0m\n\n"
 
-    s += "Unlink with \e[32mbrew unlink netcdf\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies netcdf\e[0m\n\n" if core_netcdf_linked
+    if core_netcdf_linked
+      s += "Unlink with \e[32mbrew unlink netcdf\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies netcdf\e[0m\n\n"
+    end
     s
   end
 end
@@ -28,18 +30,17 @@ class OsgeoNetcdf < Formula
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    sha256 "57ab2d6562197db772ca5a21fbeb74f2a3e68a374771b536110387ae5ecb3383" => :catalina
-    sha256 "57ab2d6562197db772ca5a21fbeb74f2a3e68a374771b536110387ae5ecb3383" => :mojave
-    sha256 "57ab2d6562197db772ca5a21fbeb74f2a3e68a374771b536110387ae5ecb3383" => :high_sierra
+    sha256 catalina:    "57ab2d6562197db772ca5a21fbeb74f2a3e68a374771b536110387ae5ecb3383"
+    sha256 mojave:      "57ab2d6562197db772ca5a21fbeb74f2a3e68a374771b536110387ae5ecb3383"
+    sha256 high_sierra: "57ab2d6562197db772ca5a21fbeb74f2a3e68a374771b536110387ae5ecb3383"
   end
 
   # keg_only "netcdf is already provided by homebrew/core"
   # we will verify that other versions are not linked
-  depends_on Unlinked
-
   depends_on "cmake" => :build
-  depends_on "gcc" # for gfortran
+  depends_on "gcc"
   depends_on "hdf5"
+  depends_on Unlinked # for gfortran
 
   uses_from_macos "curl"
 
@@ -143,7 +144,7 @@ class OsgeoNetcdf < Formula
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lnetcdf",
                    "-o", "test"
     if head?
-      assert_match /^\d+(?:\.\d+)+/, `./test`
+      assert_match(/^\d+(?:\.\d+)+/, `./test`)
     else
       assert_equal version.to_s, `./test`
     end

--- a/Formula/osgeo-postgresql.rb
+++ b/Formula/osgeo-postgresql.rb
@@ -1,46 +1,58 @@
 class Unlinked < Requirement
   fatal true
 
-  satisfy(:build_env => false) { !osgeo_postgresql11_linked && !osgeo_postgresql10_linked && !core_postgresql_linked && !core_postgresql11_linked && !core_postgresql10_linked }
+  satisfy(build_env: false) do
+    !osgeo_postgresql11_linked && !osgeo_postgresql10_linked && !core_postgresql_linked && !core_postgresql11_linked && !core_postgresql10_linked
+  end
 
   def osgeo_postgresql11_linked
     Formula["osgeo-postgresql@11"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def osgeo_postgresql10_linked
     Formula["osgeo-postgresql@10"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def core_postgresql_linked
     Formula["postgresql"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def core_postgresql11_linked
     Formula["postgresql@11"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def core_postgresql10_linked
     Formula["postgresql@10"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def message
     s = "\033[31mYou have other linked versions!\e[0m\n\n"
 
-    s += "Unlink with \e[32mbrew unlink osgeo-postgresql@11\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies osgeo-postgresql@11\e[0m\n\n" if osgeo_postgresql11_linked
-    s += "Unlink with \e[32mbrew unlink osgeo-postgresql@10\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies osgeo-postgresql@10\e[0m\n\n" if osgeo_postgresql10_linked
-    s += "Unlink with \e[32mbrew unlink postgresql\e[0m or remove with brew \e[32muninstall --ignore-dependencies postgresql\e[0m\n\n" if core_postgresql_linked
-    s += "Unlink with \e[32mbrew unlink postgresql@11\e[0m or remove with brew \e[32muninstall --ignore-dependencies postgresq@11\e[0m\n\n" if core_postgresql11_linked
-    s += "Unlink with \e[32mbrew unlink postgresql@10\e[0m or remove with brew \e[32muninstall --ignore-dependencies postgresq@10\e[0m\n\n" if core_postgresql10_linked
+    if osgeo_postgresql11_linked
+      s += "Unlink with \e[32mbrew unlink osgeo-postgresql@11\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies osgeo-postgresql@11\e[0m\n\n"
+    end
+    if osgeo_postgresql10_linked
+      s += "Unlink with \e[32mbrew unlink osgeo-postgresql@10\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies osgeo-postgresql@10\e[0m\n\n"
+    end
+    if core_postgresql_linked
+      s += "Unlink with \e[32mbrew unlink postgresql\e[0m or remove with brew \e[32muninstall --ignore-dependencies postgresql\e[0m\n\n"
+    end
+    if core_postgresql11_linked
+      s += "Unlink with \e[32mbrew unlink postgresql@11\e[0m or remove with brew \e[32muninstall --ignore-dependencies postgresq@11\e[0m\n\n"
+    end
+    if core_postgresql10_linked
+      s += "Unlink with \e[32mbrew unlink postgresql@10\e[0m or remove with brew \e[32muninstall --ignore-dependencies postgresq@10\e[0m\n\n"
+    end
     s
   end
 end
@@ -51,34 +63,33 @@ class OsgeoPostgresql < Formula
   url "https://ftp.postgresql.org/pub/source/v12.4/postgresql-12.4.tar.bz2"
   sha256 "bee93fbe2c32f59419cb162bcc0145c58da9a8644ee154a30b9a5ce47de606cc"
 
+  head "https://github.com/postgres/postgres.git", branch: "master"
+
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    sha256 "c2ffac019bf7f8aed005fb3a0c50d2cfe30b7daf3a1edda9e415e64e0328a153" => :catalina
-    sha256 "c2ffac019bf7f8aed005fb3a0c50d2cfe30b7daf3a1edda9e415e64e0328a153" => :mojave
-    sha256 "c2ffac019bf7f8aed005fb3a0c50d2cfe30b7daf3a1edda9e415e64e0328a153" => :high_sierra
+    sha256 catalina:    "c2ffac019bf7f8aed005fb3a0c50d2cfe30b7daf3a1edda9e415e64e0328a153"
+    sha256 mojave:      "c2ffac019bf7f8aed005fb3a0c50d2cfe30b7daf3a1edda9e415e64e0328a153"
+    sha256 high_sierra: "c2ffac019bf7f8aed005fb3a0c50d2cfe30b7daf3a1edda9e415e64e0328a153"
   end
 
-  #revision 1
-
-  head "https://github.com/postgres/postgres.git", :branch => "master"
+  # revision 1
 
   option "with-cellar", "Use /Cellar in the path configuration (necessary for migration)"
 
   # keg_only "postgresql is already provided by homebrew/core"
   # we will verify that other versions are not linked
-  depends_on Unlinked
-
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "icu4c"
-  depends_on "openldap" # libldap
-  depends_on "openssl"
-  depends_on "readline"
-  depends_on "tcl-tk"
   depends_on "krb5"
   depends_on "libxml2"
-  depends_on "python"
+  depends_on "openldap"
+  depends_on "openssl"
   depends_on "perl"
+  depends_on "python"
+  depends_on "readline"
+  depends_on "tcl-tk"
+  depends_on Unlinked # libldap
   depends_on "zlib"
   # depends_on "e2fsprogs"
 
@@ -99,7 +110,7 @@ class OsgeoPostgresql < Formula
     # ENV["PYTHON"] = which("python3")
     ENV["PYTHON"] = "#{Formula["python"].opt_bin}/python3"
 
-    args = %W[
+    args = %w[
       --disable-debug
       --enable-thread-safety
       --with-bonjour
@@ -117,19 +128,19 @@ class OsgeoPostgresql < Formula
       --with-python
     ]
 
-    if build.with? "cellar"
-      args += [
+    args += if build.with? "cellar"
+      [
         "--prefix=#{prefix}",
         # "bindir=#{bin}", # if define this, will refer to /Cellar
         "--datadir=#{share}/postgresql",
         "--libdir=#{lib}/postgresql",
         "--sysconfdir=#{etc}",
         "--docdir=#{doc}/postgresql",
-        "--includedir=#{include}/postgresql"
+        "--includedir=#{include}/postgresql",
       ]
     else
       # this is to not have the reference to /Cellar in the files
-      args += [
+      [
         "--prefix=#{prefix}",
         # "--bindir=#{HOMEBREW_PREFIX}/bin",
         "--sysconfdir=#{HOMEBREW_PREFIX}/etc",
@@ -188,7 +199,7 @@ class OsgeoPostgresql < Formula
     # Attempting to fix that by adding a dependency on `open-sp` doesn't
     # work and the build errors out on generating the documentation, so
     # for now let's simply omit it so we can package Postgresql for Mojave.
-    # if DevelopmentTools.clang_build_version >= 1000
+    #  if DevelopmentTools.clang_build_version >= 1000
     system "make", "all"
     system "make", "-C", "contrib", "install", "all", *dirs
     system "make", "install", "all", *dirs
@@ -204,110 +215,108 @@ class OsgeoPostgresql < Formula
     #   system "#{bin}/initdb", "#{var}/postgresql"
     # end
 
-    if build.with? "cellar"
-      if File.exists?(File.join("#{HOMEBREW_PREFIX}/Cellar", "osgeo-postgis@2.4"))
-        unless File.exists?("#{HOMEBREW_PREFIX}/opt/osgeo-postgresql/lib/postgresql/postgis-2.4.so")
-          # copy postgis 2.4.x to postgresql 11.x
-          FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_share}/postgresql/.", "#{share}/postgresql/"
-          FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/.", "#{lib}/postgresql/"
-          # FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/rtpostgis-2.4.so", "#{lib}/postgresql/"
-          # FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/postgis-2.4.so", "#{lib}/postgresql/"
-          # FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/postgis_topology-2.4.so", "#{lib}/postgresql/"
-        end
-      end
-
-      # if File.exists?(File.join("#{HOMEBREW_PREFIX}/Cellar", "osgeo-postgis"))
-      #   unless File.exists?("#{HOMEBREW_PREFIX}/opt/osgeo-postgresql/lib/postgresql/postgis-2.5.so")
-      #     # install postgis 2.5.x to postgresql 11.x
-      #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_share}/postgresql/.", "#{share}/postgresql/"
-      #     # FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/.", "#{lib}/postgresql/"
-      #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/rtpostgis-2.5.so", "#{lib}/postgresql/"
-      #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/postgis-2.5.so", "#{lib}/postgresql/"
-      #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/postgis_topology-2.5.so", "#{lib}/postgresql/"
-      #   end
-      # end
+    if build.with? "cellar" && File.exist?(File.join("#{HOMEBREW_PREFIX}/Cellar",
+"osgeo-postgis@2.4")) && !File.exist?("#{HOMEBREW_PREFIX}/opt/osgeo-postgresql/lib/postgresql/postgis-2.4.so")
+      # copy postgis 2.4.x to postgresql 11.x
+      FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_share}/postgresql/.", "#{share}/postgresql/"
+      FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/.", "#{lib}/postgresql/"
+      # FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/rtpostgis-2.4.so", "#{lib}/postgresql/"
+      # FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/postgis-2.4.so", "#{lib}/postgresql/"
+      # FileUtils.cp_r "#{Formula["osgeo-postgis@2.4"].opt_lib}/postgresql/postgis_topology-2.4.so", "#{lib}/postgresql/"
     end
+
+    # if File.exists?(File.join("#{HOMEBREW_PREFIX}/Cellar", "osgeo-postgis"))
+    #   unless File.exists?("#{HOMEBREW_PREFIX}/opt/osgeo-postgresql/lib/postgresql/postgis-2.5.so")
+    #     # install postgis 2.5.x to postgresql 11.x
+    #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_share}/postgresql/.", "#{share}/postgresql/"
+    #     # FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/.", "#{lib}/postgresql/"
+    #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/rtpostgis-2.5.so", "#{lib}/postgresql/"
+    #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/postgis-2.5.so", "#{lib}/postgresql/"
+    #     FileUtils.cp_r "#{Formula["osgeo-postgis"].opt_lib}/postgresql/postgis_topology-2.5.so", "#{lib}/postgresql/"
+    #   end
+    # end
   end
 
-  def caveats; <<~EOS
+  def caveats
+    <<~EOS
+      1 - If you need to link "#{name}":
 
-    1 - If you need to link "#{name}":
+            \e[32m$ brew link #{name} --force\e[0m
 
-          \e[32m$ brew link #{name} --force\e[0m
+          Previously unlink any other version that you have installed.
 
-        Previously unlink any other version that you have installed.
+      2 - If you need to init postgresql just execute the following command:
 
-    2 - If you need to init postgresql just execute the following command:
+            \e[32m$ initdb #{HOMEBREW_PREFIX}/var/postgresql -E utf8 --locale=en_US.UTF-8\e[0m
 
-          \e[32m$ initdb #{HOMEBREW_PREFIX}/var/postgresql -E utf8 --locale=en_US.UTF-8\e[0m
+          If the file "#{HOMEBREW_PREFIX}/var/postgresql/PG_VERSION" exists,
+          it is because you already created this in postinstall or a previous installation.
 
-        If the file "#{HOMEBREW_PREFIX}/var/postgresql/PG_VERSION" exists,
-        it is because you already created this in postinstall or a previous installation.
+      3 - Start using:
 
-    3 - Start using:
+            \e[32m$ pg_ctl start -D /usr/local/var/postgresql\e[0m
 
-          \e[32m$ pg_ctl start -D /usr/local/var/postgresql\e[0m
+      4 - Connecting to our new database
 
-    4 - Connecting to our new database
+            \e[32m$ psql -h localhost -d postgres\e[0m
 
-          \e[32m$ psql -h localhost -d postgres\e[0m
+      Note:
 
-    Note:
+        - Services doesn't start properly, add to \e[32mhomebrew.mxcl.osgeo-postgresql.plist\e[0m:
 
-      - Services doesn't start properly, add to \e[32mhomebrew.mxcl.osgeo-postgresql.plist\e[0m:
+            \e[32m<key>EnvironmentVariables</key>\e[0m
+            \e[32m<dict>\e[0m
+              \e[32m<key>LC_ALL</key>\e[0m
+              \e[32m<string>en_US.UTF-8</string>\e[0m
+            \e[32m</dict>\e[0m
 
-          \e[32m<key>EnvironmentVariables</key>\e[0m
-          \e[32m<dict>\e[0m
-            \e[32m<key>LC_ALL</key>\e[0m
-            \e[32m<string>en_US.UTF-8</string>\e[0m
-          \e[32m</dict>\e[0m
+            issue: \e[32mhttps://github.com/OSGeo/homebrew-osgeo4mac/issues/1075#issuecomment-490052517\e[0m
 
-          issue: \e[32mhttps://github.com/OSGeo/homebrew-osgeo4mac/issues/1075#issuecomment-490052517\e[0m
+        - Could not bind ipv6 address database system was not properly shut:
 
-      - Could not bind ipv6 address database system was not properly shut:
+            \e[32m$ sudo lsof -i :5432\e[0m (search PID)
 
-          \e[32m$ sudo lsof -i :5432\e[0m (search PID)
+            \e[32m$ kill PID\e[0m
 
-          \e[32m$ kill PID\e[0m
+        - To migrate existing data from a previous major version of PostgreSQL run:
 
-      - To migrate existing data from a previous major version of PostgreSQL run:
+            \e[32m$ brew postgresql-upgrade-database\e[0m
 
-          \e[32m$ brew postgresql-upgrade-database\e[0m
+        - For more information see our page with documentation:
 
-      - For more information see our page with documentation:
-
-          \e[32mhttps://osgeo.github.io/homebrew-osgeo4mac\e[0m
+            \e[32mhttps://osgeo.github.io/homebrew-osgeo4mac\e[0m
     EOS
   end
 
-  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql start"
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>KeepAlive</key>
-      <true/>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/postgres</string>
-        <string>-D</string>
-        <string>#{var}/postgresql</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/postgresql.log</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/postgresql.log</string>
-    </dict>
-    </plist>
-  EOS
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/postgres</string>
+          <string>-D</string>
+          <string>#{var}/postgresql</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/postgresql.log</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/postgresql.log</string>
+      </dict>
+      </plist>
+    EOS
   end
 
   test do

--- a/Formula/osgeo-proj.rb
+++ b/Formula/osgeo-proj.rb
@@ -1,18 +1,20 @@
 class Unlinked < Requirement
   fatal true
 
-  satisfy(:build_env => false) { !core_proj_linked }
+  satisfy(build_env: false) { !core_proj_linked }
 
   def core_proj_linked
     Formula["proj"].linked_keg.exist?
   rescue
-    return false
+    false
   end
 
   def message
     s = "\033[31mYou have other linked versions!\e[0m\n\n"
 
-    s += "Unlink with \e[32mbrew unlink proj\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies proj\e[0m\n\n" if core_proj_linked
+    if core_proj_linked
+      s += "Unlink with \e[32mbrew unlink proj\e[0m or remove with \e[32mbrew uninstall --ignore-dependencies proj\e[0m\n\n"
+    end
     s
   end
 end
@@ -25,41 +27,40 @@ class OsgeoProj < Formula
 
   bottle do
     root_url "https://bottle.download.osgeo.org"
-    sha256 "729a8816d46c6f3293951bf7f68d6b6e32bb13e4c75f339a29140f44b5ffa2e7" => :catalina
-    sha256 "729a8816d46c6f3293951bf7f68d6b6e32bb13e4c75f339a29140f44b5ffa2e7" => :mojave
-    sha256 "729a8816d46c6f3293951bf7f68d6b6e32bb13e4c75f339a29140f44b5ffa2e7" => :high_sierra
+    sha256 catalina:    "729a8816d46c6f3293951bf7f68d6b6e32bb13e4c75f339a29140f44b5ffa2e7"
+    sha256 mojave:      "729a8816d46c6f3293951bf7f68d6b6e32bb13e4c75f339a29140f44b5ffa2e7"
+    sha256 high_sierra: "729a8816d46c6f3293951bf7f68d6b6e32bb13e4c75f339a29140f44b5ffa2e7"
   end
 
   # revision 1
 
   # keg_only "proj is already provided by homebrew/core"
   # we will verify that other versions are not linked
-  depends_on Unlinked
-
   head do
-    url "https://github.com/OSGeo/PROJ.git", :branch => "master"
+    url "https://github.com/OSGeo/PROJ.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
   depends_on "pkg-config" => :build
+  depends_on Unlinked
   # depends_on "libtiff" Proj >7
 
-  conflicts_with "blast", :because => "both install a `libproj.a` library"
+  conflicts_with "blast", because: "both install a `libproj.a` library"
 
   skip_clean :la
 
   # The datum grid files are required to support datum shifting Proj <7
   # TODO: If needed, include content from https://github.com/OSGeo/PROJ-data
-  #resource "projdata" do
+  # resource "projdata" do
   resource "datumgrid" do
     url "https://download.osgeo.org/proj/proj-datumgrid-1.8.zip"
     sha256 "b9838ae7e5f27ee732fb0bfed618f85b36e8bb56d7afb287d506338e9f33861e"
   end
 
   def install
-    #(buildpath).install resource("projdata")
+    # (buildpath).install resource("projdata")
     (buildpath/"nad").install resource("datumgrid")
 
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
# Description

On a regular `brew upgrade`, I experienced a certain amount of warning messages of the following kind:

```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the osgeo/osgeo4mac tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/osgeo/homebrew-osgeo4mac/Formula/osgeo-postgresql.rb:58
```

## Type of change

This PR includes changes automatically applied using `brew style --fix`.

# How Has This Been Tested?

Due to the kind of change, no tests had been performed.

* Homebrew 3.1.2-42-gb6a6260
* Operating System: macOS Mojave 10.14.6 (18G9027)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules